### PR TITLE
Add Support for PVs and PVCs

### DIFF
--- a/pkg/cmd/issues.go
+++ b/pkg/cmd/issues.go
@@ -29,8 +29,10 @@ func NewIssuesCommand() *cobra.Command {
 
 	f := cmdutil.NewFactory(matchVersionFlags)
 
-	cmd.AddCommand(newPodsCommand(f, o))
 	cmd.AddCommand(newJobsCommand(f, o))
+	cmd.AddCommand(newPodsCommand(f, o))
+	cmd.AddCommand(newPVCsCommand(f, o))
+	cmd.AddCommand(newPVsCommand(f, o))
 
 	return cmd
 }

--- a/pkg/cmd/pvcs.go
+++ b/pkg/cmd/pvcs.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/ricoberger/kubectl-issues/pkg/cmd/utils"
+	"github.com/ricoberger/kubectl-issues/pkg/writer"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	storageutil "k8s.io/kubectl/pkg/util/storage"
+)
+
+type PVCsOptions struct {
+	IssuesOptions
+}
+
+func newPVCsOptions(options IssuesOptions) *PVCsOptions {
+	return &PVCsOptions{
+		IssuesOptions: options,
+	}
+}
+
+func newPVCsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
+	o := newPVCsOptions(options)
+
+	cmd := &cobra.Command{
+		Use:          "pvcs",
+		Short:        "List issues with PersistentVolumeClaims",
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(factory, c); err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			noHeader := c.Flag("no-headers").Changed
+			if err := o.Run(ctx, noHeader); err != nil {
+				fmt.Fprintln(options.Streams.ErrOut, err.Error())
+				return nil
+			}
+			return nil
+		},
+	}
+
+	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (o *PVCsOptions) Run(ctx context.Context, noHeader bool) error {
+	client, err := o.GetClient()
+	if err != nil {
+		return err
+	}
+
+	pvcs, err := client.CoreV1().PersistentVolumeClaims(o.namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	var matrix [][]string
+
+	for _, pvc := range pvcs.Items {
+		if pvc.Status.Phase != "Bound" {
+			accessModes := storageutil.GetAccessModesAsString(pvc.Status.AccessModes)
+			storage := pvc.Status.Capacity[corev1.ResourceStorage]
+			capacity := storage.String()
+
+			row := []string{pvc.Namespace, pvc.Name, string(pvc.Status.Phase), pvc.Spec.VolumeName, capacity, accessModes, *pvc.Spec.StorageClassName, utils.GetAge(pvc.CreationTimestamp)}
+			matrix = append(matrix, row)
+		}
+	}
+
+	headers := []string{"NAMESPACE", "NAME", "STATUS", "VOLUME", "CAPACITY", "ACCESS MODES", "STORAGECLASS", "AGE"}
+
+	buf := bytes.NewBuffer(nil)
+	writer.WriteResults(buf, headers, matrix, noHeader)
+	fmt.Printf("%s", buf.String())
+
+	return nil
+}

--- a/pkg/cmd/pvs.go
+++ b/pkg/cmd/pvs.go
@@ -1,0 +1,86 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/ricoberger/kubectl-issues/pkg/cmd/utils"
+	"github.com/ricoberger/kubectl-issues/pkg/writer"
+
+	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	storageutil "k8s.io/kubectl/pkg/util/storage"
+)
+
+type PVsOptions struct {
+	IssuesOptions
+}
+
+func newPVsOptions(options IssuesOptions) *PVsOptions {
+	return &PVsOptions{
+		IssuesOptions: options,
+	}
+}
+
+func newPVsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
+	o := newPVsOptions(options)
+
+	cmd := &cobra.Command{
+		Use:          "pvs",
+		Short:        "List issues with PersistentVolumes",
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(factory, c); err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			noHeader := c.Flag("no-headers").Changed
+			if err := o.Run(ctx, noHeader); err != nil {
+				fmt.Fprintln(options.Streams.ErrOut, err.Error())
+				return nil
+			}
+			return nil
+		},
+	}
+
+	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (o *PVsOptions) Run(ctx context.Context, noHeader bool) error {
+	client, err := o.GetClient()
+	if err != nil {
+		return err
+	}
+
+	pvs, err := client.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	var matrix [][]string
+
+	for _, pv := range pvs.Items {
+		if pv.Status.Phase != "Bound" {
+			accessModes := storageutil.GetAccessModesAsString(pv.Spec.AccessModes)
+			storage := pv.Spec.Capacity[corev1.ResourceStorage]
+			capacity := storage.String()
+
+			row := []string{pv.Name, capacity, accessModes, string(pv.Spec.PersistentVolumeReclaimPolicy), string(pv.Status.Phase), fmt.Sprintf("%s/%s", pv.Spec.ClaimRef.Namespace, pv.Spec.ClaimRef.Name), pv.Spec.StorageClassName, pv.Status.Reason, utils.GetAge(pv.CreationTimestamp)}
+			matrix = append(matrix, row)
+		}
+	}
+
+	headers := []string{"NAME", "CAPACITY", "ACCESS MODES", "RECLAIM POLICY", "STATUS", "CLAIM", "STORAGECLASS", "REASON", "AGE"}
+
+	buf := bytes.NewBuffer(nil)
+	writer.WriteResults(buf, headers, matrix, noHeader)
+	fmt.Printf("%s", buf.String())
+
+	return nil
+}


### PR DESCRIPTION
This commit adds support for PersistentVolumes and PersistentVolumeClaims via the new `kubectl issues pvs` and `kubectl issues pvcs` commands.