### PR TITLE
Add Support for Deployments

### DIFF
--- a/pkg/cmd/deploys.go
+++ b/pkg/cmd/deploys.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+
+	"github.com/ricoberger/kubectl-issues/pkg/cmd/utils"
+	"github.com/ricoberger/kubectl-issues/pkg/writer"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+type DeploysOptions struct {
+	IssuesOptions
+}
+
+func newDeploysOptions(options IssuesOptions) *DeploysOptions {
+	return &DeploysOptions{
+		IssuesOptions: options,
+	}
+}
+
+func newDeploysCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
+	o := newDeploysOptions(options)
+
+	cmd := &cobra.Command{
+		Use:          "deploys",
+		Short:        "List issues with Deployments",
+		SilenceUsage: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(factory, c); err != nil {
+				return err
+			}
+
+			ctx := context.Background()
+			noHeader := c.Flag("no-headers").Changed
+			if err := o.Run(ctx, noHeader); err != nil {
+				fmt.Fprintln(options.Streams.ErrOut, err.Error())
+				return nil
+			}
+			return nil
+		},
+	}
+
+	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}
+
+func (o *DeploysOptions) Run(ctx context.Context, noHeader bool) error {
+	client, err := o.GetClient()
+	if err != nil {
+		return err
+	}
+
+	deploys, err := client.AppsV1().Deployments(o.namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	var matrix [][]string
+
+	for _, deploy := range deploys.Items {
+		if deploy.Status.Replicas != deploy.Status.ReadyReplicas || deploy.Status.Replicas != deploy.Status.UpdatedReplicas || deploy.Status.Replicas != deploy.Status.AvailableReplicas {
+			row := []string{deploy.Namespace, deploy.Name, fmt.Sprintf("%d/%d", deploy.Status.ReadyReplicas, deploy.Status.Replicas), fmt.Sprintf("%d", deploy.Status.UpdatedReplicas), fmt.Sprintf("%d", deploy.Status.AvailableReplicas), utils.GetAge(deploy.CreationTimestamp)}
+			matrix = append(matrix, row)
+		}
+	}
+
+	headers := []string{"NAMESPACE", "NAME", "READY", "UP-TO-DATE", "AVAILABLE", "AGE"}
+
+	buf := bytes.NewBuffer(nil)
+	writer.WriteResults(buf, headers, matrix, noHeader)
+	fmt.Printf("%s", buf.String())
+
+	return nil
+}

--- a/pkg/cmd/dss.go
+++ b/pkg/cmd/dss.go
@@ -70,7 +70,7 @@ func (o *DSsOptions) Run(ctx context.Context, noHeader bool) error {
 		}
 	}
 
-	headers := []string{"NAMESPACE", "NAME", "DESIRED", "Current", "READY", "UP-TO-DATE", "AVAILABLE", "AGE"}
+	headers := []string{"NAMESPACE", "NAME", "DESIRED", "CURRENT", "READY", "UP-TO-DATE", "AVAILABLE", "AGE"}
 
 	buf := bytes.NewBuffer(nil)
 	writer.WriteResults(buf, headers, matrix, noHeader)

--- a/pkg/cmd/issues.go
+++ b/pkg/cmd/issues.go
@@ -29,6 +29,7 @@ func NewIssuesCommand() *cobra.Command {
 
 	f := cmdutil.NewFactory(matchVersionFlags)
 
+	cmd.AddCommand(newDeploysCommand(f, o))
 	cmd.AddCommand(newDSsCommand(f, o))
 	cmd.AddCommand(newJobsCommand(f, o))
 	cmd.AddCommand(newNodesCommand(f, o))


### PR DESCRIPTION
Add support for Deployments via the new `kubectl issues deploys` command.