### PR TITLE
Rename Commands and Add Aliases

### DIFF
--- a/pkg/cmd/daemonsets.go
+++ b/pkg/cmd/daemonsets.go
@@ -13,21 +13,22 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
-type DSsOptions struct {
+type DaemonSetsOptions struct {
 	IssuesOptions
 }
 
-func newDSsOptions(options IssuesOptions) *DSsOptions {
-	return &DSsOptions{
+func newDaemonSetsOptions(options IssuesOptions) *DaemonSetsOptions {
+	return &DaemonSetsOptions{
 		IssuesOptions: options,
 	}
 }
 
-func newDSsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
-	o := newDSsOptions(options)
+func newDaemonSetsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
+	o := newDaemonSetsOptions(options)
 
 	cmd := &cobra.Command{
-		Use:          "dss",
+		Use:          "daemonsets",
+		Aliases:      []string{"daemonset", "ds"},
 		Short:        "List issues with DaemonSets",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
@@ -50,20 +51,20 @@ func newDSsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Comman
 	return cmd
 }
 
-func (o *DSsOptions) Run(ctx context.Context, noHeader bool) error {
+func (o *DaemonSetsOptions) Run(ctx context.Context, noHeader bool) error {
 	client, err := o.GetClient()
 	if err != nil {
 		return err
 	}
 
-	dss, err := client.AppsV1().DaemonSets(o.namespace).List(ctx, metav1.ListOptions{})
+	daemonSets, err := client.AppsV1().DaemonSets(o.namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
 	var matrix [][]string
 
-	for _, ds := range dss.Items {
+	for _, ds := range daemonSets.Items {
 		if ds.Status.DesiredNumberScheduled != ds.Status.CurrentNumberScheduled || ds.Status.DesiredNumberScheduled != ds.Status.NumberReady || ds.Status.DesiredNumberScheduled != ds.Status.UpdatedNumberScheduled || ds.Status.DesiredNumberScheduled != ds.Status.NumberAvailable || ds.Status.NumberMisscheduled > 0 {
 			row := []string{ds.Namespace, ds.Name, fmt.Sprintf("%d", ds.Status.DesiredNumberScheduled), fmt.Sprintf("%d", ds.Status.CurrentNumberScheduled), fmt.Sprintf("%d", ds.Status.NumberReady), fmt.Sprintf("%d", ds.Status.UpdatedNumberScheduled), fmt.Sprintf("%d", ds.Status.NumberAvailable), utils.GetAge(ds.CreationTimestamp)}
 			matrix = append(matrix, row)

--- a/pkg/cmd/deployments.go
+++ b/pkg/cmd/deployments.go
@@ -13,21 +13,22 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
-type DeploysOptions struct {
+type DeploymentsOptions struct {
 	IssuesOptions
 }
 
-func newDeploysOptions(options IssuesOptions) *DeploysOptions {
-	return &DeploysOptions{
+func newDeploymentsOptions(options IssuesOptions) *DeploymentsOptions {
+	return &DeploymentsOptions{
 		IssuesOptions: options,
 	}
 }
 
-func newDeploysCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
-	o := newDeploysOptions(options)
+func newDeploymentsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
+	o := newDeploymentsOptions(options)
 
 	cmd := &cobra.Command{
-		Use:          "deploys",
+		Use:          "deployments",
+		Aliases:      []string{"deployment", "deploy"},
 		Short:        "List issues with Deployments",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
@@ -50,20 +51,20 @@ func newDeploysCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Co
 	return cmd
 }
 
-func (o *DeploysOptions) Run(ctx context.Context, noHeader bool) error {
+func (o *DeploymentsOptions) Run(ctx context.Context, noHeader bool) error {
 	client, err := o.GetClient()
 	if err != nil {
 		return err
 	}
 
-	deploys, err := client.AppsV1().Deployments(o.namespace).List(ctx, metav1.ListOptions{})
+	deployments, err := client.AppsV1().Deployments(o.namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
 	var matrix [][]string
 
-	for _, deploy := range deploys.Items {
+	for _, deploy := range deployments.Items {
 		if deploy.Status.Replicas != deploy.Status.ReadyReplicas || deploy.Status.Replicas != deploy.Status.UpdatedReplicas || deploy.Status.Replicas != deploy.Status.AvailableReplicas {
 			row := []string{deploy.Namespace, deploy.Name, fmt.Sprintf("%d/%d", deploy.Status.ReadyReplicas, deploy.Status.Replicas), fmt.Sprintf("%d", deploy.Status.UpdatedReplicas), fmt.Sprintf("%d", deploy.Status.AvailableReplicas), utils.GetAge(deploy.CreationTimestamp)}
 			matrix = append(matrix, row)

--- a/pkg/cmd/issues.go
+++ b/pkg/cmd/issues.go
@@ -29,13 +29,13 @@ func NewIssuesCommand() *cobra.Command {
 
 	f := cmdutil.NewFactory(matchVersionFlags)
 
-	cmd.AddCommand(newDeploysCommand(f, o))
-	cmd.AddCommand(newDSsCommand(f, o))
+	cmd.AddCommand(newDaemonSetsCommand(f, o))
+	cmd.AddCommand(newDeploymentsCommand(f, o))
 	cmd.AddCommand(newJobsCommand(f, o))
 	cmd.AddCommand(newNodesCommand(f, o))
+	cmd.AddCommand(newPersistentVolumeClaimsCommand(f, o))
+	cmd.AddCommand(newPersistentVolumesCommand(f, o))
 	cmd.AddCommand(newPodsCommand(f, o))
-	cmd.AddCommand(newPVCsCommand(f, o))
-	cmd.AddCommand(newPVsCommand(f, o))
 	cmd.AddCommand(newReplicaSetsCommand(f, o))
 	cmd.AddCommand(newStatefulSetsCommand(f, o))
 

--- a/pkg/cmd/jobs.go
+++ b/pkg/cmd/jobs.go
@@ -28,6 +28,7 @@ func newJobsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Comma
 
 	cmd := &cobra.Command{
 		Use:          "jobs",
+		Aliases:      []string{"job"},
 		Short:        "List issues with Jobs",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {

--- a/pkg/cmd/nodes.go
+++ b/pkg/cmd/nodes.go
@@ -30,6 +30,7 @@ func newNodesCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Comm
 
 	cmd := &cobra.Command{
 		Use:          "nodes",
+		Aliases:      []string{"node", "no"},
 		Short:        "List issues with Nodes",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {

--- a/pkg/cmd/persistentvolumeclaims.go
+++ b/pkg/cmd/persistentvolumeclaims.go
@@ -15,21 +15,22 @@ import (
 	storageutil "k8s.io/kubectl/pkg/util/storage"
 )
 
-type PVCsOptions struct {
+type PersistentVolumeClaimsOptions struct {
 	IssuesOptions
 }
 
-func newPVCsOptions(options IssuesOptions) *PVCsOptions {
-	return &PVCsOptions{
+func newPersistentVolumeClaimsOptions(options IssuesOptions) *PersistentVolumeClaimsOptions {
+	return &PersistentVolumeClaimsOptions{
 		IssuesOptions: options,
 	}
 }
 
-func newPVCsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
-	o := newPVCsOptions(options)
+func newPersistentVolumeClaimsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
+	o := newPersistentVolumeClaimsOptions(options)
 
 	cmd := &cobra.Command{
-		Use:          "pvcs",
+		Use:          "persistentvolumeclaims",
+		Aliases:      []string{"persistentvolumeclaim", "pvc"},
 		Short:        "List issues with PersistentVolumeClaims",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
@@ -52,7 +53,7 @@ func newPVCsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Comma
 	return cmd
 }
 
-func (o *PVCsOptions) Run(ctx context.Context, noHeader bool) error {
+func (o *PersistentVolumeClaimsOptions) Run(ctx context.Context, noHeader bool) error {
 	client, err := o.GetClient()
 	if err != nil {
 		return err

--- a/pkg/cmd/persistentvolumes.go
+++ b/pkg/cmd/persistentvolumes.go
@@ -15,21 +15,22 @@ import (
 	storageutil "k8s.io/kubectl/pkg/util/storage"
 )
 
-type PVsOptions struct {
+type PersistentVolumesOptions struct {
 	IssuesOptions
 }
 
-func newPVsOptions(options IssuesOptions) *PVsOptions {
-	return &PVsOptions{
+func newPersistentVolumesOptions(options IssuesOptions) *PersistentVolumesOptions {
+	return &PersistentVolumesOptions{
 		IssuesOptions: options,
 	}
 }
 
-func newPVsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
-	o := newPVsOptions(options)
+func newPersistentVolumesCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
+	o := newPersistentVolumesOptions(options)
 
 	cmd := &cobra.Command{
-		Use:          "pvs",
+		Use:          "persistentvolumes",
+		Aliases:      []string{"persistentvolume", "pv"},
 		Short:        "List issues with PersistentVolumes",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
@@ -52,7 +53,7 @@ func newPVsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Comman
 	return cmd
 }
 
-func (o *PVsOptions) Run(ctx context.Context, noHeader bool) error {
+func (o *PersistentVolumesOptions) Run(ctx context.Context, noHeader bool) error {
 	client, err := o.GetClient()
 	if err != nil {
 		return err

--- a/pkg/cmd/pods.go
+++ b/pkg/cmd/pods.go
@@ -29,6 +29,7 @@ func newPodsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Comma
 
 	cmd := &cobra.Command{
 		Use:          "pods",
+		Aliases:      []string{"pod", "po"},
 		Short:        "List issues with Pods",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {

--- a/pkg/cmd/replicasets.go
+++ b/pkg/cmd/replicasets.go
@@ -28,6 +28,7 @@ func newReplicaSetsCommand(factory cmdutil.Factory, options IssuesOptions) *cobr
 
 	cmd := &cobra.Command{
 		Use:          "replicasets",
+		Aliases:      []string{"replicaset", "rs"},
 		Short:        "List issues with ReplicaSets",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {

--- a/pkg/cmd/statefulsets.go
+++ b/pkg/cmd/statefulsets.go
@@ -28,6 +28,7 @@ func newStatefulSetsCommand(factory cmdutil.Factory, options IssuesOptions) *cob
 
 	cmd := &cobra.Command{
 		Use:          "statefulsets",
+		Aliases:      []string{"statefulset", "sts"},
 		Short:        "List issues with StatefulSets",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {


### PR DESCRIPTION
Rework the name of the commands and add aliases so that `kubectl issues` can be used similar to `kubectl get`.

Available Commands:
  - `daemonsets`: List issues with DaemonSets
  - `deployments`: List issues with Deployments
  - `jobs`: List issues with Jobs
  - `nodes`: List issues with Nodes
  - `persistentvolumeclaims`: List issues with PersistentVolumeClaims
  - `persistentvolumes`: List issues with PersistentVolumes
  - `pods`: List issues with Pods
  - `replicasets`: List issues with ReplicaSets
  - `statefulsets`: List issues with StatefulSets