### PR TITLE
fix(pods): align pod status, ready and restarts with kubectl

### DIFF
--- a/pkg/pods/pods.go
+++ b/pkg/pods/pods.go
@@ -3,6 +3,7 @@ package pods
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/ricoberger/kubectl-issues/pkg/cmd/utils"
@@ -36,129 +37,270 @@ func ListUnhealthy(ctx context.Context, client kubernetes.Interface, namespace, 
 	var result []Pod
 
 	for _, pod := range list.Items {
-		var shouldReady int64
-		var isReady int64
-		var restarts int32
-		var restartAge string
+		s := describePod(pod)
 
-		for _, containerStatus := range pod.Status.ContainerStatuses {
-			shouldReady++
-			if containerStatus.Ready {
-				isReady++
-			}
-
-			if containerStatus.RestartCount > 0 {
-				restarts = restarts + containerStatus.RestartCount
-
-				if containerStatus.LastTerminationState.Terminated != nil && containerStatus.LastTerminationState.Terminated.ExitCode != 0 && containerStatus.LastTerminationState.Terminated.FinishedAt.After(time.Now().Add(-24*time.Hour)) {
-					restartAge = utils.GetAge(containerStatus.LastTerminationState.Terminated.FinishedAt)
-				}
-			}
+		// Skip Pods that completed successfully.
+		if pod.Status.Phase == corev1.PodSucceeded && s.status == "Completed" {
+			continue
 		}
 
-		status := GetStatus(pod)
-
-		if pod.Status.Phase != corev1.PodSucceeded || status != "Completed" {
-			if !IsHealthy(pod) || shouldReady != isReady || restartAge != "" {
-				restartsCell := fmt.Sprintf("%d", restarts)
-				if restartAge != "" {
-					restartsCell = fmt.Sprintf("%d (%s ago)", restarts, restartAge)
-				}
-
-				result = append(result, Pod{
-					Context:   contextName,
-					Namespace: pod.Namespace,
-					Name:      pod.Name,
-					Ready:     fmt.Sprintf("%d/%d", isReady, shouldReady),
-					Status:    status,
-					Restarts:  restartsCell,
-					Age:       utils.GetAge(pod.CreationTimestamp),
-				})
-			}
+		// Only surface Pods that have an actual issue: not Ready (which folds
+		// in container readiness, sidecars and readiness gates), or a container
+		// that crashed recently (so flapping Pods that are momentarily Ready are
+		// still reported).
+		if hasPodReadyCondition(pod.Status.Conditions) && !hasRecentCrash(pod) {
+			continue
 		}
+
+		result = append(result, Pod{
+			Context:   contextName,
+			Namespace: pod.Namespace,
+			Name:      pod.Name,
+			Ready:     s.ready(),
+			Status:    s.status,
+			Restarts:  s.restartsCell(),
+			Age:       utils.GetAge(pod.CreationTimestamp),
+		})
 	}
 
 	return result, nil
 }
 
-// GetStatus returns the human readable status of a Pod, similar to the STATUS
-// column of "kubectl get pods".
-func GetStatus(pod corev1.Pod) string {
-	switch pod.Status.Phase {
-	case corev1.PodSucceeded:
-		for _, status := range pod.Status.ContainerStatuses {
-			if status.State.Terminated != nil {
-				return string(status.State.Terminated.Reason)
-			}
-		}
-	case corev1.PodFailed:
-		for _, condition := range pod.Status.Conditions {
-			if condition.Type == corev1.PodInitialized && condition.Status == corev1.ConditionFalse {
-				return "Init:Error"
-			}
-			for _, status := range pod.Status.ContainerStatuses {
-				if status.State.Terminated != nil {
-					return string(status.State.Terminated.Reason)
-				}
-			}
-		}
-	case corev1.PodRunning:
-		for _, status := range pod.Status.ContainerStatuses {
-			if status.State.Waiting != nil {
-				return string(status.State.Waiting.Reason)
-			}
-		}
-	case corev1.PodPending:
-		for _, status := range pod.Status.ContainerStatuses {
-			if status.State.Waiting != nil {
-				return string(status.State.Waiting.Reason)
-			}
-		}
-	default:
-		if pod.DeletionTimestamp != nil && !pod.DeletionTimestamp.IsZero() {
-			return "Terminating"
-		}
-	}
+// hasRecentCrash reports whether any container of the Pod (init or regular)
+// terminated with a non-zero exit code within the last 24 hours.
+func hasRecentCrash(pod corev1.Pod) bool {
+	cutoff := time.Now().Add(-24 * time.Hour)
 
-	return string(pod.Status.Phase)
-}
-
-// IsHealthy returns true if the given Pod is considered healthy.
-func IsHealthy(pod corev1.Pod) bool {
-	switch pod.Status.Phase {
-	case corev1.PodSucceeded:
-		for _, status := range pod.Status.ContainerStatuses {
-			if status.State.Terminated != nil && status.State.Terminated.ExitCode != 0 {
-				return false
+	check := func(statuses []corev1.ContainerStatus) bool {
+		for _, cs := range statuses {
+			term := cs.LastTerminationState.Terminated
+			if cs.RestartCount > 0 && term != nil && term.ExitCode != 0 && term.FinishedAt.After(cutoff) {
+				return true
 			}
 		}
-	case corev1.PodPending:
-		if isWaitingContainers(pod) {
-			return false
-		}
-	case corev1.PodRunning:
-		for _, condition := range pod.Status.Conditions {
-			if condition.Status == corev1.ConditionFalse {
-				return false
-			}
-		}
-
-		if isWaitingContainers(pod) {
-			return false
-		}
-
-	default:
 		return false
 	}
 
-	return true
+	return check(pod.Status.InitContainerStatuses) || check(pod.Status.ContainerStatuses)
 }
 
-func isWaitingContainers(pod corev1.Pod) bool {
-	for _, st := range pod.Status.ContainerStatuses {
-		if st.State.Waiting != nil {
+// nodeUnreachablePodReason is the reason set on a Pod's status when the node it
+// runs on becomes unreachable. It mirrors NodeUnreachablePodReason from
+// k8s.io/kubernetes/pkg/util/node, which is not importable here.
+const nodeUnreachablePodReason = "NodeLost"
+
+// summary holds the READY, STATUS and RESTARTS values for a Pod as printed by
+// "kubectl get pods".
+type summary struct {
+	readyContainers int
+	totalContainers int
+	status          string
+	restarts        int
+	lastRestartDate metav1.Time
+}
+
+// ready returns the formatted READY column, e.g. "1/2".
+func (s summary) ready() string {
+	return fmt.Sprintf("%d/%d", s.readyContainers, s.totalContainers)
+}
+
+// restartsCell returns the formatted RESTARTS column, e.g. "3" or
+// "3 (5m ago)".
+func (s summary) restartsCell() string {
+	if s.restarts != 0 && !s.lastRestartDate.IsZero() {
+		return fmt.Sprintf("%d (%s ago)", s.restarts, utils.GetAge(s.lastRestartDate))
+	}
+	return strconv.Itoa(s.restarts)
+}
+
+// GetStatus returns the human readable status of a Pod, matching the STATUS
+// column of "kubectl get pods".
+func GetStatus(pod corev1.Pod) string {
+	return describePod(pod).status
+}
+
+// describePod computes the READY, STATUS and RESTARTS values for a Pod. The
+// logic is ported from the upstream printPod function in
+// k8s.io/kubernetes/pkg/printers/internalversion so that the result stays
+// consistent with kubectl, including init/sidecar containers, scheduling gates,
+// terminating/unknown pods, restart counts and signal/exit-code reasons.
+func describePod(pod corev1.Pod) summary {
+	restarts := 0
+	restartableInitContainerRestarts := 0
+	totalContainers := len(pod.Spec.Containers)
+	readyContainers := 0
+	lastRestartDate := metav1.Time{}
+	lastRestartableInitContainerRestartDate := metav1.Time{}
+
+	podPhase := pod.Status.Phase
+	reason := string(podPhase)
+	if pod.Status.Reason != "" {
+		reason = pod.Status.Reason
+	}
+
+	// If the Pod carries {type:PodScheduled, reason:SchedulingGated}, set the
+	// reason to "SchedulingGated".
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodScheduled && condition.Reason == corev1.PodReasonSchedulingGated {
+			reason = corev1.PodReasonSchedulingGated
+		}
+	}
+
+	initContainers := make(map[string]*corev1.Container)
+	for i := range pod.Spec.InitContainers {
+		initContainers[pod.Spec.InitContainers[i].Name] = &pod.Spec.InitContainers[i]
+		if isRestartableInitContainer(&pod.Spec.InitContainers[i]) {
+			totalContainers++
+		}
+	}
+
+	initializing := false
+	for i := range pod.Status.InitContainerStatuses {
+		container := pod.Status.InitContainerStatuses[i]
+		restarts += int(container.RestartCount)
+		if container.LastTerminationState.Terminated != nil {
+			terminatedDate := container.LastTerminationState.Terminated.FinishedAt
+			if lastRestartDate.Before(&terminatedDate) {
+				lastRestartDate = terminatedDate
+			}
+		}
+		if isRestartableInitContainer(initContainers[container.Name]) {
+			restartableInitContainerRestarts += int(container.RestartCount)
+			if container.LastTerminationState.Terminated != nil {
+				terminatedDate := container.LastTerminationState.Terminated.FinishedAt
+				if lastRestartableInitContainerRestartDate.Before(&terminatedDate) {
+					lastRestartableInitContainerRestartDate = terminatedDate
+				}
+			}
+		}
+		switch {
+		case container.State.Terminated != nil && container.State.Terminated.ExitCode == 0:
+			continue
+		case isRestartableInitContainer(initContainers[container.Name]) &&
+			container.Started != nil && *container.Started:
+			if container.Ready {
+				readyContainers++
+			}
+			continue
+		case container.State.Terminated != nil:
+			// initialization has failed
+			if len(container.State.Terminated.Reason) == 0 {
+				if container.State.Terminated.Signal != 0 {
+					reason = fmt.Sprintf("Init:Signal:%d", container.State.Terminated.Signal)
+				} else {
+					reason = fmt.Sprintf("Init:ExitCode:%d", container.State.Terminated.ExitCode)
+				}
+			} else {
+				reason = "Init:" + container.State.Terminated.Reason
+			}
+			initializing = true
+		case container.State.Waiting != nil && len(container.State.Waiting.Reason) > 0 && container.State.Waiting.Reason != "PodInitializing":
+			reason = "Init:" + container.State.Waiting.Reason
+			initializing = true
+		default:
+			reason = fmt.Sprintf("Init:%d/%d", i, len(pod.Spec.InitContainers))
+			initializing = true
+		}
+		break
+	}
+
+	if !initializing || isPodInitializedConditionTrue(&pod.Status) {
+		restarts = restartableInitContainerRestarts
+		lastRestartDate = lastRestartableInitContainerRestartDate
+		hasRunning := false
+		errorReason := ""
+		for i := len(pod.Status.ContainerStatuses) - 1; i >= 0; i-- {
+			container := pod.Status.ContainerStatuses[i]
+
+			restarts += int(container.RestartCount)
+			if container.LastTerminationState.Terminated != nil {
+				terminatedDate := container.LastTerminationState.Terminated.FinishedAt
+				if lastRestartDate.Before(&terminatedDate) {
+					lastRestartDate = terminatedDate
+				}
+			}
+			switch {
+			case container.State.Waiting != nil && container.State.Waiting.Reason != "":
+				reason = container.State.Waiting.Reason
+			case container.State.Terminated != nil:
+				if len(container.State.Terminated.Reason) > 0 {
+					reason = container.State.Terminated.Reason
+				} else if container.State.Terminated.Signal != 0 {
+					reason = fmt.Sprintf("Signal:%d", container.State.Terminated.Signal)
+				} else {
+					reason = fmt.Sprintf("ExitCode:%d", container.State.Terminated.ExitCode)
+				}
+				if container.State.Terminated.ExitCode != 0 {
+					errorReason = reason
+				}
+			case container.Ready && container.State.Running != nil:
+				hasRunning = true
+				readyContainers++
+			}
+		}
+
+		// Change the pod status back to "Running" if there is at least one
+		// container still reporting as "Running".
+		if reason == "Completed" {
+			if hasRunning && hasPodReadyCondition(pod.Status.Conditions) {
+				reason = "Running"
+			} else if errorReason != "" {
+				reason = errorReason
+			} else if hasRunning {
+				reason = "NotReady"
+			}
+		}
+	}
+
+	if pod.DeletionTimestamp != nil && pod.Status.Reason == nodeUnreachablePodReason {
+		reason = "Unknown"
+	} else if pod.DeletionTimestamp != nil && !isPodPhaseTerminal(podPhase) {
+		reason = "Terminating"
+	}
+
+	return summary{
+		readyContainers: readyContainers,
+		totalContainers: totalContainers,
+		status:          reason,
+		restarts:        restarts,
+		lastRestartDate: lastRestartDate,
+	}
+}
+
+// isRestartableInitContainer reports whether the given init container is a
+// sidecar (restartPolicy: Always).
+func isRestartableInitContainer(initContainer *corev1.Container) bool {
+	if initContainer == nil || initContainer.RestartPolicy == nil {
+		return false
+	}
+	return *initContainer.RestartPolicy == corev1.ContainerRestartPolicyAlways
+}
+
+// isPodInitializedConditionTrue reports whether the Pod has the Initialized
+// condition set to True.
+func isPodInitializedConditionTrue(status *corev1.PodStatus) bool {
+	for _, condition := range status.Conditions {
+		if condition.Type != corev1.PodInitialized {
+			continue
+		}
+		return condition.Status == corev1.ConditionTrue
+	}
+	return false
+}
+
+// hasPodReadyCondition reports whether the Pod has the Ready condition set to
+// True.
+func hasPodReadyCondition(conditions []corev1.PodCondition) bool {
+	for _, condition := range conditions {
+		if condition.Type == corev1.PodReady && condition.Status == corev1.ConditionTrue {
 			return true
 		}
 	}
 	return false
+}
+
+// isPodPhaseTerminal reports whether the given phase is a terminal phase
+// (Succeeded or Failed).
+func isPodPhaseTerminal(phase corev1.PodPhase) bool {
+	return phase == corev1.PodFailed || phase == corev1.PodSucceeded
 }

--- a/pkg/pods/pods_test.go
+++ b/pkg/pods/pods_test.go
@@ -1,0 +1,306 @@
+package pods
+
+import (
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func boolPtr(b bool) *bool { return &b }
+
+func restartPolicyPtr(p corev1.ContainerRestartPolicy) *corev1.ContainerRestartPolicy {
+	return &p
+}
+
+func TestGetStatus(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+
+	tests := []struct {
+		name string
+		pod  corev1.Pod
+		want string
+	}{
+		{
+			name: "running and ready",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					},
+				},
+			},
+			want: "Running",
+		},
+		{
+			name: "crash loop back off",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
+					},
+				},
+			},
+			want: "CrashLoopBackOff",
+		},
+		{
+			name: "completed job",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodSucceeded,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed", ExitCode: 0}}},
+					},
+				},
+			},
+			want: "Completed",
+		},
+		{
+			name: "evicted pod uses status reason",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase:  corev1.PodFailed,
+					Reason: "Evicted",
+				},
+			},
+			want: "Evicted",
+		},
+		{
+			name: "terminating running pod",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					},
+				},
+			},
+			want: "Terminating",
+		},
+		{
+			name: "node lost shows unknown",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &now},
+				Status: corev1.PodStatus{
+					Phase:  corev1.PodRunning,
+					Reason: "NodeLost",
+				},
+			},
+			want: "Unknown",
+		},
+		{
+			name: "init container crash loop",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{Name: "init"}},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "init", State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
+					},
+				},
+			},
+			want: "Init:CrashLoopBackOff",
+		},
+		{
+			name: "init container progress",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{{Name: "init1"}, {Name: "init2"}},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "init1", State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "PodInitializing"}}},
+					},
+				},
+			},
+			want: "Init:0/2",
+		},
+		{
+			name: "terminated without reason uses exit code",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 137}}},
+					},
+				},
+			},
+			want: "ExitCode:137",
+		},
+		{
+			name: "terminated without reason uses signal",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Signal: 9}}},
+					},
+				},
+			},
+			want: "Signal:9",
+		},
+		{
+			name: "scheduling gated",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodPending,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodScheduled, Reason: corev1.PodReasonSchedulingGated},
+					},
+				},
+			},
+			want: "SchedulingGated",
+		},
+		{
+			name: "completed reason but a container still running and ready",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					Conditions: []corev1.PodCondition{
+						{Type: corev1.PodReady, Status: corev1.ConditionTrue},
+					},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Completed", ExitCode: 0}}},
+						{Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					},
+				},
+			},
+			want: "Running",
+		},
+		{
+			name: "sidecar init container started does not block main containers",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{Name: "sidecar", RestartPolicy: restartPolicyPtr(corev1.ContainerRestartPolicyAlways)},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "sidecar", Started: boolPtr(true), Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "ImagePullBackOff"}}},
+					},
+				},
+			},
+			want: "ImagePullBackOff",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetStatus(tt.pod); got != tt.want {
+				t.Errorf("GetStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDescribePodReadyAndRestarts(t *testing.T) {
+	old := metav1.NewTime(time.Now().Add(-5 * time.Minute))
+	older := metav1.NewTime(time.Now().Add(-2 * time.Hour))
+
+	tests := []struct {
+		name         string
+		pod          corev1.Pod
+		wantReady    string
+		wantRestarts string
+	}{
+		{
+			name: "sidecar counts towards total and ready",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "app"}},
+					InitContainers: []corev1.Container{
+						{Name: "sidecar", RestartPolicy: restartPolicyPtr(corev1.ContainerRestartPolicyAlways)},
+						{Name: "setup"},
+					},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{Name: "setup", State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{ExitCode: 0}}},
+						{Name: "sidecar", Started: boolPtr(true), Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: "app", Ready: true, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}},
+					},
+				},
+			},
+			wantReady:    "2/2",
+			wantRestarts: "0",
+		},
+		{
+			name: "restarts include init and main containers",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers:     []corev1.Container{{Name: "app"}},
+					InitContainers: []corev1.Container{{Name: "sidecar", RestartPolicy: restartPolicyPtr(corev1.ContainerRestartPolicyAlways)}},
+				},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:         "sidecar",
+							Started:      boolPtr(true),
+							Ready:        true,
+							RestartCount: 2,
+							State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+							LastTerminationState: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, FinishedAt: older},
+							},
+						},
+					},
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:         "app",
+							Ready:        true,
+							RestartCount: 3,
+							State:        corev1.ContainerState{Running: &corev1.ContainerStateRunning{}},
+							LastTerminationState: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, FinishedAt: old},
+							},
+						},
+					},
+				},
+			},
+			wantReady:    "2/2",
+			wantRestarts: "5 (5m ago)",
+		},
+		{
+			name: "no restarts shows plain count",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+				Status: corev1.PodStatus{
+					Phase: corev1.PodRunning,
+					ContainerStatuses: []corev1.ContainerStatus{
+						{Name: "app", Ready: false, State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}}},
+					},
+				},
+			},
+			wantReady:    "0/1",
+			wantRestarts: "0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := describePod(tt.pod)
+			if got := s.ready(); got != tt.wantReady {
+				t.Errorf("ready() = %q, want %q", got, tt.wantReady)
+			}
+			if got := s.restartsCell(); got != tt.wantRestarts {
+				t.Errorf("restartsCell() = %q, want %q", got, tt.wantRestarts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The STATUS, READY and RESTARTS columns were computed with a simplified, hand-rolled approximation that diverged from `kubectl get pods` for many real cases: terminating, evicted and node-lost pods, init/sidecar containers, signal/exit-code terminations and restart totals.

Port the upstream printPod logic from k8s.io/kubernetes/pkg/printers/internalversion into a single describePod helper so all three columns share one kubectl-faithful source, and have GetStatus delegate to it.

Replace the bespoke IsHealthy/ready-count filter with the canonical Pod Ready condition, which already folds in container readiness, sidecars and readiness gates; the now-redundant IsHealthy and isWaitingContainers helpers are removed. The recent-crash heuristic now also inspects init and sidecar containers. As a result, transient not-Ready pods (e.g. Pending or ContainerCreating) are now surfaced, which previously could be skipped.