### PR TITLE
feat(pods): only report Ready Pods with repeated recent crashes

### DIFF
--- a/pkg/cmd/pods.go
+++ b/pkg/cmd/pods.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/ricoberger/kubectl-issues/pkg/pods"
 	"github.com/ricoberger/kubectl-issues/pkg/writer"
@@ -14,6 +15,8 @@ import (
 
 type PodsOptions struct {
 	IssuesOptions
+	restartThreshold int
+	restartWindow    time.Duration
 }
 
 func newPodsOptions(options IssuesOptions) *PodsOptions {
@@ -47,6 +50,10 @@ func newPodsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Comma
 
 	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
 
+	defaults := pods.DefaultOptions()
+	cmd.Flags().IntVar(&o.restartThreshold, "restart-threshold", defaults.RestartThreshold, "Minimum restart count before a Ready Pod with a recent crash is reported. 0 only reports Pods which are not Ready, 1 reports any recent crash.")
+	cmd.Flags().DurationVar(&o.restartWindow, "restart-window", defaults.RestartWindow, "How recent the last crash of a container must be for a Ready Pod to be reported.")
+
 	return cmd
 }
 
@@ -56,7 +63,10 @@ func (o *PodsOptions) Run(ctx context.Context, noHeader bool) error {
 		return err
 	}
 
-	unhealthy, err := pods.ListUnhealthy(ctx, client, o.namespace, "")
+	unhealthy, err := pods.ListUnhealthy(ctx, client, o.namespace, "", pods.Options{
+		RestartThreshold: o.restartThreshold,
+		RestartWindow:    o.restartWindow,
+	})
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/tui.go
+++ b/pkg/cmd/tui.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/ricoberger/kubectl-issues/pkg/pods"
 	"github.com/ricoberger/kubectl-issues/pkg/tui"
 
 	"github.com/spf13/cobra"
@@ -9,17 +10,20 @@ import (
 
 func newTUICommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Command {
 	var contexts []string
+	podsOptions := pods.DefaultOptions()
 
 	cmd := &cobra.Command{
 		Use:          "tui",
 		Short:        "Show all unhealthy Pods across one or more contexts in a TUI",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
-			return tui.Start(contexts, options.ConfigFlags)
+			return tui.Start(contexts, options.ConfigFlags, podsOptions)
 		},
 	}
 
 	cmd.Flags().StringArrayVar(&contexts, "context", nil, "The name of the kubeconfig context to use. Can be specified multiple times to show unhealthy Pods from multiple clusters.")
+	cmd.Flags().IntVar(&podsOptions.RestartThreshold, "restart-threshold", podsOptions.RestartThreshold, "Minimum restart count before a Ready Pod with a recent crash is reported. 0 only reports Pods which are not Ready, 1 reports any recent crash.")
+	cmd.Flags().DurationVar(&podsOptions.RestartWindow, "restart-window", podsOptions.RestartWindow, "How recent the last crash of a container must be for a Ready Pod to be reported.")
 
 	return cmd
 }

--- a/pkg/pods/pods.go
+++ b/pkg/pods/pods.go
@@ -99,7 +99,7 @@ func hasRecentCrash(pod corev1.Pod, opts Options) bool {
 	check := func(statuses []corev1.ContainerStatus) bool {
 		for _, cs := range statuses {
 			term := cs.LastTerminationState.Terminated
-			if cs.RestartCount >= int32(opts.RestartThreshold) && term != nil && term.ExitCode != 0 && term.FinishedAt.After(cutoff) {
+			if int(cs.RestartCount) >= opts.RestartThreshold && term != nil && term.ExitCode != 0 && term.FinishedAt.After(cutoff) {
 				return true
 			}
 		}

--- a/pkg/pods/pods.go
+++ b/pkg/pods/pods.go
@@ -25,10 +25,29 @@ type Pod struct {
 	Age       string
 }
 
+// Options tunes which Pods are considered unhealthy by ListUnhealthy.
+type Options struct {
+	// RestartThreshold is the minimum lifetime restart count a container must
+	// have before a Ready Pod is reported for a recent crash. A value of 0
+	// disables reporting Ready Pods entirely, 1 reports any recent crash.
+	RestartThreshold int
+	// RestartWindow is how recent the last crash of a container must be for a
+	// Ready Pod to be reported.
+	RestartWindow time.Duration
+}
+
+// DefaultOptions returns the default Options used to detect unhealthy Pods.
+func DefaultOptions() Options {
+	return Options{
+		RestartThreshold: 3,
+		RestartWindow:    24 * time.Hour,
+	}
+}
+
 // ListUnhealthy returns all unhealthy Pods in the given namespace. If the
 // namespace is empty, Pods from all namespaces are returned. The contextName is
 // only used to populate the Context field of the returned Pods.
-func ListUnhealthy(ctx context.Context, client kubernetes.Interface, namespace, contextName string) ([]Pod, error) {
+func ListUnhealthy(ctx context.Context, client kubernetes.Interface, namespace, contextName string, opts Options) ([]Pod, error) {
 	list, err := client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
@@ -46,9 +65,9 @@ func ListUnhealthy(ctx context.Context, client kubernetes.Interface, namespace, 
 
 		// Only surface Pods that have an actual issue: not Ready (which folds
 		// in container readiness, sidecars and readiness gates), or a container
-		// that crashed recently (so flapping Pods that are momentarily Ready are
-		// still reported).
-		if hasPodReadyCondition(pod.Status.Conditions) && !hasRecentCrash(pod) {
+		// that restarted repeatedly and crashed recently (so flapping Pods that
+		// are momentarily Ready are still reported).
+		if hasPodReadyCondition(pod.Status.Conditions) && !hasRecentCrash(pod, opts) {
 			continue
 		}
 
@@ -67,14 +86,20 @@ func ListUnhealthy(ctx context.Context, client kubernetes.Interface, namespace, 
 }
 
 // hasRecentCrash reports whether any container of the Pod (init or regular)
-// terminated with a non-zero exit code within the last 24 hours.
-func hasRecentCrash(pod corev1.Pod) bool {
-	cutoff := time.Now().Add(-24 * time.Hour)
+// restarted at least opts.RestartThreshold times in total and terminated with
+// a non-zero exit code within opts.RestartWindow. A threshold of 0 disables
+// the check, so a single one-off restart does not flag an otherwise Ready Pod.
+func hasRecentCrash(pod corev1.Pod, opts Options) bool {
+	if opts.RestartThreshold <= 0 {
+		return false
+	}
+
+	cutoff := time.Now().Add(-opts.RestartWindow)
 
 	check := func(statuses []corev1.ContainerStatus) bool {
 		for _, cs := range statuses {
 			term := cs.LastTerminationState.Terminated
-			if cs.RestartCount > 0 && term != nil && term.ExitCode != 0 && term.FinishedAt.After(cutoff) {
+			if cs.RestartCount >= int32(opts.RestartThreshold) && term != nil && term.ExitCode != 0 && term.FinishedAt.After(cutoff) {
 				return true
 			}
 		}

--- a/pkg/pods/pods_test.go
+++ b/pkg/pods/pods_test.go
@@ -304,3 +304,125 @@ func TestDescribePodReadyAndRestarts(t *testing.T) {
 		})
 	}
 }
+
+func TestHasRecentCrash(t *testing.T) {
+	recent := metav1.NewTime(time.Now().Add(-2 * time.Hour))
+	stale := metav1.NewTime(time.Now().Add(-48 * time.Hour))
+
+	crashedPod := func(restarts int32, exitCode int32, finishedAt metav1.Time) corev1.Pod {
+		return corev1.Pod{
+			Status: corev1.PodStatus{
+				ContainerStatuses: []corev1.ContainerStatus{
+					{
+						Name:         "app",
+						RestartCount: restarts,
+						LastTerminationState: corev1.ContainerState{
+							Terminated: &corev1.ContainerStateTerminated{ExitCode: exitCode, FinishedAt: finishedAt},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name string
+		pod  corev1.Pod
+		opts Options
+		want bool
+	}{
+		{
+			name: "restarts above threshold with recent crash",
+			pod:  crashedPod(3, 1, recent),
+			opts: DefaultOptions(),
+			want: true,
+		},
+		{
+			name: "single restart below threshold",
+			pod:  crashedPod(1, 1, recent),
+			opts: DefaultOptions(),
+			want: false,
+		},
+		{
+			name: "restarts above threshold but crash outside window",
+			pod:  crashedPod(5, 1, stale),
+			opts: DefaultOptions(),
+			want: false,
+		},
+		{
+			name: "restarts above threshold but clean exit",
+			pod:  crashedPod(5, 0, recent),
+			opts: DefaultOptions(),
+			want: false,
+		},
+		{
+			name: "threshold zero disables the check",
+			pod:  crashedPod(10, 1, recent),
+			opts: Options{RestartThreshold: 0, RestartWindow: 24 * time.Hour},
+			want: false,
+		},
+		{
+			name: "threshold one matches any recent crash",
+			pod:  crashedPod(1, 1, recent),
+			opts: Options{RestartThreshold: 1, RestartWindow: 24 * time.Hour},
+			want: true,
+		},
+		{
+			name: "custom window excludes older crash",
+			pod:  crashedPod(3, 1, recent),
+			opts: Options{RestartThreshold: 3, RestartWindow: time.Hour},
+			want: false,
+		},
+		{
+			name: "threshold not summed across containers",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					ContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:         "app",
+							RestartCount: 2,
+							LastTerminationState: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, FinishedAt: recent},
+							},
+						},
+						{
+							Name:         "sidecar",
+							RestartCount: 2,
+							LastTerminationState: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, FinishedAt: recent},
+							},
+						},
+					},
+				},
+			},
+			opts: DefaultOptions(),
+			want: false,
+		},
+		{
+			name: "init container crash counts",
+			pod: corev1.Pod{
+				Status: corev1.PodStatus{
+					InitContainerStatuses: []corev1.ContainerStatus{
+						{
+							Name:         "init",
+							RestartCount: 3,
+							LastTerminationState: corev1.ContainerState{
+								Terminated: &corev1.ContainerStateTerminated{ExitCode: 1, FinishedAt: recent},
+							},
+						},
+					},
+				},
+			},
+			opts: DefaultOptions(),
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasRecentCrash(tt.pod, tt.opts); got != tt.want {
+				t.Errorf("hasRecentCrash() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -66,7 +66,7 @@ type podsMsg struct {
 }
 
 // fetchCmd fetches the unhealthy Pods from all contexts in parallel.
-func fetchCmd(clients []ContextClient) tea.Cmd {
+func fetchCmd(clients []ContextClient, podsOptions pods.Options) tea.Cmd {
 	return func() tea.Msg {
 		var (
 			wg       sync.WaitGroup
@@ -84,7 +84,7 @@ func fetchCmd(clients []ContextClient) tea.Cmd {
 				ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
 				defer cancel()
 
-				result, err := pods.ListUnhealthy(ctx, client.Client, "", client.Name)
+				result, err := pods.ListUnhealthy(ctx, client.Client, "", client.Name, podsOptions)
 
 				mu.Lock()
 				defer mu.Unlock()
@@ -120,17 +120,19 @@ type Model struct {
 	ScreenWidth  int
 	ScreenHeight int
 
-	Clients []ContextClient
-	Table   table.Model
+	Clients     []ContextClient
+	PodsOptions pods.Options
+	Table       table.Model
 
 	count       int
 	lastErr     error
 	lastUpdated time.Time
 }
 
-func NewModel(clients []ContextClient) tea.Model {
+func NewModel(clients []ContextClient, podsOptions pods.Options) tea.Model {
 	return &Model{
-		Clients: clients,
+		Clients:     clients,
+		PodsOptions: podsOptions,
 		Table: table.New([]table.Column{
 			table.NewFlexColumn(columnKeyContext, "Context", 1).WithStyle(lipgloss.NewStyle().Align(lipgloss.Left)),
 			table.NewFlexColumn(columnKeyNamespace, "Namespace", 1).WithStyle(lipgloss.NewStyle().Align(lipgloss.Left)),
@@ -150,7 +152,7 @@ func NewModel(clients []ContextClient) tea.Model {
 }
 
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(fetchCmd(m.Clients), tickEvery())
+	return tea.Batch(fetchCmd(m.Clients, m.PodsOptions), tickEvery())
 }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
@@ -168,7 +170,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+c", "q":
 			cmds = append(cmds, tea.Quit)
 		case "r":
-			cmds = append(cmds, fetchCmd(m.Clients))
+			cmds = append(cmds, fetchCmd(m.Clients, m.PodsOptions))
 		}
 	case tea.WindowSizeMsg:
 		m.ScreenWidth = msg.Width
@@ -183,7 +185,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.lastUpdated = time.Now()
 		m.Table = m.Table.WithRows(generateRows(msg.items))
 	case TickMsg:
-		cmds = append(cmds, fetchCmd(m.Clients), tickEvery())
+		cmds = append(cmds, fetchCmd(m.Clients, m.PodsOptions), tickEvery())
 	}
 
 	m.Table = m.Table.WithStaticFooter(m.footer())

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"fmt"
 
+	"github.com/ricoberger/kubectl-issues/pkg/pods"
+
 	tea "charm.land/bubbletea/v2"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	"k8s.io/client-go/kubernetes"
@@ -17,8 +19,9 @@ type ContextClient struct {
 }
 
 // Start builds a Kubernetes client for every given context and starts the TUI.
-// If no contexts are given, the current context of the kubeconfig is used.
-func Start(contexts []string, configFlags *genericclioptions.ConfigFlags) error {
+// If no contexts are given, the current context of the kubeconfig is used. The
+// podsOptions tune which Pods are considered unhealthy.
+func Start(contexts []string, configFlags *genericclioptions.ConfigFlags, podsOptions pods.Options) error {
 	kubeconfig := ""
 	if configFlags != nil && configFlags.KubeConfig != nil {
 		kubeconfig = *configFlags.KubeConfig
@@ -38,7 +41,7 @@ func Start(contexts []string, configFlags *genericclioptions.ConfigFlags) error 
 		clients = append(clients, ContextClient{Name: resolvedName, Client: client})
 	}
 
-	model := NewModel(clients)
+	model := NewModel(clients, podsOptions)
 
 	p := tea.NewProgram(model)
 	if _, err := p.Run(); err != nil {


### PR DESCRIPTION
Previously any Ready Pod whose container crashed once within the last
24 hours was listed, which surfaced one-off restarts (OOM blips, node
drain races) as issues. A Ready Pod is now only reported when the same
container has a lifetime restart count of at least 3 and its last
termination had a non-zero exit code within the window. Pods that are
not Ready are still always reported.

Both limits are tunable via `--restart-threshold` and `--restart-window`
on the `pods` and `tui` subcommands. A threshold of 0 disables reporting
Ready Pods entirely, 1 restores the previous behavior.