### PR TITLE
feat(cmd)!: support multiple contexts in all subcommands

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,63 @@
+package client
+
+import (
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+)
+
+// ContextClient is a Kubernetes client for a single kubeconfig context. The
+// Name is the (resolved) name of the context and the Namespace is the
+// namespace to use for the context, where an empty string means all
+// namespaces.
+type ContextClient struct {
+	Name      string
+	Namespace string
+	Client    kubernetes.Interface
+}
+
+// New builds a Kubernetes client for the given kubeconfig context, using the
+// connection settings from the given config flags. If the context name is
+// empty, the current context of the kubeconfig is used. The namespace is
+// resolved from the --namespace flag if set, otherwise from the context's
+// kubeconfig entry. If allNamespaces is true, the namespace is empty so that
+// all namespaces are used.
+//
+// The config flags must be created with usePersistentConfig set to false, so
+// that a cached loader from a previous call for another context is not reused.
+func New(configFlags *genericclioptions.ConfigFlags, contextName string, allNamespaces bool) (ContextClient, error) {
+	originalContext := configFlags.Context
+	if contextName != "" {
+		configFlags.Context = &contextName
+	}
+	defer func() { configFlags.Context = originalContext }()
+
+	loader := configFlags.ToRawKubeConfigLoader()
+
+	resolvedName := contextName
+	if resolvedName == "" {
+		if rawConfig, err := loader.RawConfig(); err == nil {
+			resolvedName = rawConfig.CurrentContext
+		}
+	}
+
+	namespace := ""
+	if !allNamespaces {
+		ns, _, err := loader.Namespace()
+		if err != nil {
+			return ContextClient{}, err
+		}
+		namespace = ns
+	}
+
+	restConfig, err := loader.ClientConfig()
+	if err != nil {
+		return ContextClient{}, err
+	}
+
+	client, err := kubernetes.NewForConfig(restConfig)
+	if err != nil {
+		return ContextClient{}, err
+	}
+
+	return ContextClient{Name: resolvedName, Namespace: namespace, Client: client}, nil
+}

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -1,0 +1,128 @@
+package client
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+)
+
+func writeKubeconfig(t *testing.T) string {
+	t.Helper()
+
+	kubeconfig := `apiVersion: v1
+kind: Config
+current-context: staging
+clusters:
+  - name: cluster1
+    cluster:
+      server: https://staging.example.com
+  - name: cluster2
+    cluster:
+      server: https://production.example.com
+contexts:
+  - name: staging
+    context:
+      cluster: cluster1
+      namespace: staging-namespace
+  - name: production
+    context:
+      cluster: cluster2
+users: []
+`
+
+	path := filepath.Join(t.TempDir(), "kubeconfig")
+	if err := os.WriteFile(path, []byte(kubeconfig), 0o600); err != nil {
+		t.Fatalf("failed to write kubeconfig: %v", err)
+	}
+	return path
+}
+
+func newConfigFlags(kubeconfig, namespace string) *genericclioptions.ConfigFlags {
+	configFlags := genericclioptions.NewConfigFlags(false)
+	configFlags.KubeConfig = &kubeconfig
+	configFlags.Context = nil
+	if namespace != "" {
+		configFlags.Namespace = &namespace
+	}
+	return configFlags
+}
+
+func TestNew(t *testing.T) {
+	kubeconfig := writeKubeconfig(t)
+
+	tests := []struct {
+		name          string
+		contextName   string
+		namespace     string
+		allNamespaces bool
+		wantName      string
+		wantNamespace string
+	}{
+		{
+			name:          "empty context resolves current context and its namespace",
+			contextName:   "",
+			wantName:      "staging",
+			wantNamespace: "staging-namespace",
+		},
+		{
+			name:          "explicit context uses its default namespace",
+			contextName:   "production",
+			wantName:      "production",
+			wantNamespace: "default",
+		},
+		{
+			name:          "namespace flag overrides context namespace",
+			contextName:   "staging",
+			namespace:     "override",
+			wantName:      "staging",
+			wantNamespace: "override",
+		},
+		{
+			name:          "all namespaces yields empty namespace",
+			contextName:   "staging",
+			allNamespaces: true,
+			wantName:      "staging",
+			wantNamespace: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cc, err := New(newConfigFlags(kubeconfig, tt.namespace), tt.contextName, tt.allNamespaces)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+			if cc.Name != tt.wantName {
+				t.Errorf("Name = %q, want %q", cc.Name, tt.wantName)
+			}
+			if cc.Namespace != tt.wantNamespace {
+				t.Errorf("Namespace = %q, want %q", cc.Namespace, tt.wantNamespace)
+			}
+			if cc.Client == nil {
+				t.Error("Client is nil")
+			}
+		})
+	}
+}
+
+func TestNewUnknownContext(t *testing.T) {
+	kubeconfig := writeKubeconfig(t)
+
+	if _, err := New(newConfigFlags(kubeconfig, ""), "unknown", false); err == nil {
+		t.Fatal("New() expected error for unknown context, got nil")
+	}
+}
+
+func TestNewRestoresContext(t *testing.T) {
+	kubeconfig := writeKubeconfig(t)
+	configFlags := newConfigFlags(kubeconfig, "")
+
+	if _, err := New(configFlags, "production", false); err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if configFlags.Context != nil {
+		t.Errorf("Context = %q, want nil", *configFlags.Context)
+	}
+}

--- a/pkg/cmd/daemonsets.go
+++ b/pkg/cmd/daemonsets.go
@@ -1,12 +1,11 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
+	"github.com/ricoberger/kubectl-issues/pkg/client"
 	"github.com/ricoberger/kubectl-issues/pkg/cmd/utils"
-	"github.com/ricoberger/kubectl-issues/pkg/writer"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +22,7 @@ func newDaemonSetsOptions(options IssuesOptions) *DaemonSetsOptions {
 	}
 }
 
-func newDaemonSetsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
+func newDaemonSetsCommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Command {
 	o := newDaemonSetsOptions(options)
 
 	cmd := &cobra.Command{
@@ -32,13 +31,14 @@ func newDaemonSetsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra
 		Short:        "List issues with DaemonSets",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
-			if err := o.Complete(factory, c); err != nil {
+			if err := o.Complete(c); err != nil {
 				return err
 			}
 
 			ctx := context.Background()
 			noHeader := c.Flag("no-headers").Changed
-			if err := o.Run(ctx, noHeader); err != nil {
+			headers := []string{"NAMESPACE", "NAME", "DESIRED", "CURRENT", "READY", "UP-TO-DATE", "AVAILABLE", "AGE"}
+			if err := o.RunAcrossContexts(ctx, noHeader, headers, o.rows); err != nil {
 				fmt.Fprintln(options.Streams.ErrOut, err.Error())
 				return nil
 			}
@@ -51,15 +51,10 @@ func newDaemonSetsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra
 	return cmd
 }
 
-func (o *DaemonSetsOptions) Run(ctx context.Context, noHeader bool) error {
-	client, err := o.GetClient()
+func (o *DaemonSetsOptions) rows(ctx context.Context, contextClient client.ContextClient) ([][]string, error) {
+	daemonSets, err := contextClient.Client.AppsV1().DaemonSets(contextClient.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return err
-	}
-
-	daemonSets, err := client.AppsV1().DaemonSets(o.namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var matrix [][]string
@@ -71,11 +66,5 @@ func (o *DaemonSetsOptions) Run(ctx context.Context, noHeader bool) error {
 		}
 	}
 
-	headers := []string{"NAMESPACE", "NAME", "DESIRED", "CURRENT", "READY", "UP-TO-DATE", "AVAILABLE", "AGE"}
-
-	buf := bytes.NewBuffer(nil)
-	writer.WriteResults(buf, headers, matrix, noHeader)
-	fmt.Printf("%s", buf.String())
-
-	return nil
+	return matrix, nil
 }

--- a/pkg/cmd/deployments.go
+++ b/pkg/cmd/deployments.go
@@ -1,12 +1,11 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
+	"github.com/ricoberger/kubectl-issues/pkg/client"
 	"github.com/ricoberger/kubectl-issues/pkg/cmd/utils"
-	"github.com/ricoberger/kubectl-issues/pkg/writer"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +22,7 @@ func newDeploymentsOptions(options IssuesOptions) *DeploymentsOptions {
 	}
 }
 
-func newDeploymentsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
+func newDeploymentsCommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Command {
 	o := newDeploymentsOptions(options)
 
 	cmd := &cobra.Command{
@@ -32,13 +31,14 @@ func newDeploymentsCommand(factory cmdutil.Factory, options IssuesOptions) *cobr
 		Short:        "List issues with Deployments",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
-			if err := o.Complete(factory, c); err != nil {
+			if err := o.Complete(c); err != nil {
 				return err
 			}
 
 			ctx := context.Background()
 			noHeader := c.Flag("no-headers").Changed
-			if err := o.Run(ctx, noHeader); err != nil {
+			headers := []string{"NAMESPACE", "NAME", "READY", "UP-TO-DATE", "AVAILABLE", "AGE"}
+			if err := o.RunAcrossContexts(ctx, noHeader, headers, o.rows); err != nil {
 				fmt.Fprintln(options.Streams.ErrOut, err.Error())
 				return nil
 			}
@@ -51,15 +51,10 @@ func newDeploymentsCommand(factory cmdutil.Factory, options IssuesOptions) *cobr
 	return cmd
 }
 
-func (o *DeploymentsOptions) Run(ctx context.Context, noHeader bool) error {
-	client, err := o.GetClient()
+func (o *DeploymentsOptions) rows(ctx context.Context, contextClient client.ContextClient) ([][]string, error) {
+	deployments, err := contextClient.Client.AppsV1().Deployments(contextClient.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return err
-	}
-
-	deployments, err := client.AppsV1().Deployments(o.namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var matrix [][]string
@@ -71,11 +66,5 @@ func (o *DeploymentsOptions) Run(ctx context.Context, noHeader bool) error {
 		}
 	}
 
-	headers := []string{"NAMESPACE", "NAME", "READY", "UP-TO-DATE", "AVAILABLE", "AGE"}
-
-	buf := bytes.NewBuffer(nil)
-	writer.WriteResults(buf, headers, matrix, noHeader)
-	fmt.Printf("%s", buf.String())
-
-	return nil
+	return matrix, nil
 }

--- a/pkg/cmd/issues.go
+++ b/pkg/cmd/issues.go
@@ -8,8 +8,11 @@ import (
 var cmdExample = `  # List issues with Pods
   kubectl issues pods
 
+  # List issues with Pods across multiple contexts
+  kubectl issues pods --all-namespaces --context staging --context production
+
   # Show all unhealthy Pods across multiple contexts in a TUI
-  kubectl issues tui --context staging --context production
+  kubectl issues tui --all-namespaces --context staging --context production
 `
 
 func NewIssuesCommand() *cobra.Command {
@@ -25,7 +28,12 @@ func NewIssuesCommand() *cobra.Command {
 	cmd.PersistentFlags().Bool("no-headers", false, "Don't print headers (default print headers).")
 
 	flags := cmd.PersistentFlags()
+
+	// The context flag of the config flags is replaced with our own repeatable
+	// flag, so that issues can be listed across multiple contexts at once.
+	o.ConfigFlags.Context = nil
 	o.ConfigFlags.AddFlags(flags)
+	flags.StringArray("context", nil, "The name of the kubeconfig context to use. Can be specified multiple times to list issues from multiple clusters.")
 
 	matchVersionFlags := cmdutil.NewMatchVersionFlags(o.ConfigFlags)
 	matchVersionFlags.AddFlags(flags)

--- a/pkg/cmd/jobs.go
+++ b/pkg/cmd/jobs.go
@@ -1,12 +1,11 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
+	"github.com/ricoberger/kubectl-issues/pkg/client"
 	"github.com/ricoberger/kubectl-issues/pkg/cmd/utils"
-	"github.com/ricoberger/kubectl-issues/pkg/writer"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +22,7 @@ func newJobsOptions(options IssuesOptions) *JobsOptions {
 	}
 }
 
-func newJobsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
+func newJobsCommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Command {
 	o := newJobsOptions(options)
 
 	cmd := &cobra.Command{
@@ -32,13 +31,14 @@ func newJobsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Comma
 		Short:        "List issues with Jobs",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
-			if err := o.Complete(factory, c); err != nil {
+			if err := o.Complete(c); err != nil {
 				return err
 			}
 
 			ctx := context.Background()
 			noHeader := c.Flag("no-headers").Changed
-			if err := o.Run(ctx, noHeader); err != nil {
+			headers := []string{"NAMESPACE", "NAME", "REASON", "MESSAGE", "AGE"}
+			if err := o.RunAcrossContexts(ctx, noHeader, headers, o.rows); err != nil {
 				fmt.Fprintln(options.Streams.ErrOut, err.Error())
 				return nil
 			}
@@ -51,15 +51,10 @@ func newJobsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Comma
 	return cmd
 }
 
-func (o *JobsOptions) Run(ctx context.Context, noHeader bool) error {
-	client, err := o.GetClient()
+func (o *JobsOptions) rows(ctx context.Context, contextClient client.ContextClient) ([][]string, error) {
+	jobs, err := contextClient.Client.BatchV1().Jobs(contextClient.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return err
-	}
-
-	jobs, err := client.BatchV1().Jobs(o.namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var matrix [][]string
@@ -73,11 +68,5 @@ func (o *JobsOptions) Run(ctx context.Context, noHeader bool) error {
 		}
 	}
 
-	headers := []string{"NAMESPACE", "NAME", "REASON", "MESSAGE", "AGE"}
-
-	buf := bytes.NewBuffer(nil)
-	writer.WriteResults(buf, headers, matrix, noHeader)
-	fmt.Printf("%s", buf.String())
-
-	return nil
+	return matrix, nil
 }

--- a/pkg/cmd/nodes.go
+++ b/pkg/cmd/nodes.go
@@ -1,13 +1,12 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"strings"
 
+	"github.com/ricoberger/kubectl-issues/pkg/client"
 	"github.com/ricoberger/kubectl-issues/pkg/cmd/utils"
-	"github.com/ricoberger/kubectl-issues/pkg/writer"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -25,7 +24,7 @@ func newNodesOptions(options IssuesOptions) *NodesOptions {
 	}
 }
 
-func newNodesCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
+func newNodesCommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Command {
 	o := newNodesOptions(options)
 
 	cmd := &cobra.Command{
@@ -34,13 +33,14 @@ func newNodesCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Comm
 		Short:        "List issues with Nodes",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
-			if err := o.Complete(factory, c); err != nil {
+			if err := o.Complete(c); err != nil {
 				return err
 			}
 
 			ctx := context.Background()
 			noHeader := c.Flag("no-headers").Changed
-			if err := o.Run(ctx, noHeader); err != nil {
+			headers := []string{"NAME", "STATUS", "ROLES", "AGE", "VERSION"}
+			if err := o.RunAcrossContexts(ctx, noHeader, headers, o.rows); err != nil {
 				fmt.Fprintln(options.Streams.ErrOut, err.Error())
 				return nil
 			}
@@ -53,15 +53,10 @@ func newNodesCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Comm
 	return cmd
 }
 
-func (o *NodesOptions) Run(ctx context.Context, noHeader bool) error {
-	client, err := o.GetClient()
+func (o *NodesOptions) rows(ctx context.Context, contextClient client.ContextClient) ([][]string, error) {
+	nodes, err := contextClient.Client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return err
-	}
-
-	nodes, err := client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var matrix [][]string
@@ -73,13 +68,7 @@ func (o *NodesOptions) Run(ctx context.Context, noHeader bool) error {
 		}
 	}
 
-	headers := []string{"NAME", "STATUS", "ROLES", "AGE", "VERSION"}
-
-	buf := bytes.NewBuffer(nil)
-	writer.WriteResults(buf, headers, matrix, noHeader)
-	fmt.Printf("%s", buf.String())
-
-	return nil
+	return matrix, nil
 }
 
 func isNodeReady(conditions []corev1.NodeCondition) bool {

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -1,19 +1,24 @@
 package cmd
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"os"
+	"sync"
+
+	"github.com/ricoberger/kubectl-issues/pkg/client"
+	"github.com/ricoberger/kubectl-issues/pkg/writer"
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/kubernetes"
-	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
 type IssuesOptions struct {
 	Streams              genericclioptions.IOStreams
 	ConfigFlags          *genericclioptions.ConfigFlags
 	ResourceBuilderFlags *genericclioptions.ResourceBuilderFlags
-	namespace            string
+	contexts             []string
 	allNamespaces        bool
 }
 
@@ -22,7 +27,10 @@ func NewIssuesOptions() IssuesOptions {
 	rbFlags.WithAllNamespaces(false)
 
 	return IssuesOptions{
-		ConfigFlags:          genericclioptions.NewConfigFlags(true),
+		// The config flags must not use a persistent (cached) config, because
+		// GetClients builds one client per requested context and a cached
+		// loader would reuse the config of the first context for all others.
+		ConfigFlags:          genericclioptions.NewConfigFlags(false),
 		ResourceBuilderFlags: rbFlags,
 		Streams: genericclioptions.IOStreams{
 			In:     os.Stdin,
@@ -32,30 +40,95 @@ func NewIssuesOptions() IssuesOptions {
 	}
 }
 
-func (o *IssuesOptions) GetClient() (*kubernetes.Clientset, error) {
-	restConfig, err := o.ConfigFlags.ToRESTConfig()
-	if err != nil {
-		return nil, err
+func (o *IssuesOptions) Complete(cmd *cobra.Command) error {
+	if flag := cmd.Flag("all-namespaces"); flag != nil && flag.Changed {
+		o.allNamespaces = *o.ResourceBuilderFlags.AllNamespaces
 	}
 
-	clientSet, err := kubernetes.NewForConfig(restConfig)
+	contexts, err := cmd.Flags().GetStringArray("context")
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return clientSet, nil
+	o.contexts = contexts
+
+	return nil
 }
 
-func (o *IssuesOptions) Complete(factory cmdutil.Factory, cmd *cobra.Command) error {
-	var err error
-	o.namespace, _, err = factory.ToRawKubeConfigLoader().Namespace()
+// GetClients builds a Kubernetes client for every requested context. If no
+// contexts were requested, a single client for the current context of the
+// kubeconfig is returned.
+func (o *IssuesOptions) GetClients() ([]client.ContextClient, error) {
+	contexts := o.contexts
+	if len(contexts) == 0 {
+		contexts = []string{""}
+	}
+
+	var clients []client.ContextClient
+	for _, name := range contexts {
+		contextClient, err := client.New(o.ConfigFlags, name, o.allNamespaces)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client for context %q: %w", name, err)
+		}
+		clients = append(clients, contextClient)
+	}
+
+	return clients, nil
+}
+
+// rowsFunc collects the table rows for a single context. The returned rows
+// must not contain the context name, it is prepended by RunAcrossContexts.
+type rowsFunc func(ctx context.Context, contextClient client.ContextClient) ([][]string, error)
+
+// RunAcrossContexts collects the table rows from all requested contexts in
+// parallel and prints them as a single table with a leading CONTEXT column.
+// The rows are grouped in the order the contexts were specified. An error in
+// one context is printed to stderr and does not hide the results of the other
+// contexts.
+func (o *IssuesOptions) RunAcrossContexts(ctx context.Context, noHeader bool, headers []string, rows rowsFunc) error {
+	clients, err := o.GetClients()
 	if err != nil {
 		return err
 	}
 
-	if cmd.Flag("all-namespaces").Changed {
-		o.allNamespaces = *o.ResourceBuilderFlags.AllNamespaces
-		o.namespace = ""
+	type result struct {
+		rows [][]string
+		err  error
 	}
+
+	results := make([]result, len(clients))
+
+	var wg sync.WaitGroup
+	for i, contextClient := range clients {
+		wg.Add(1)
+
+		go func(i int, contextClient client.ContextClient) {
+			defer wg.Done()
+
+			contextRows, err := rows(ctx, contextClient)
+			if err != nil {
+				results[i].err = fmt.Errorf("%s: %w", contextClient.Name, err)
+				return
+			}
+
+			for _, row := range contextRows {
+				results[i].rows = append(results[i].rows, append([]string{contextClient.Name}, row...))
+			}
+		}(i, contextClient)
+	}
+	wg.Wait()
+
+	var matrix [][]string
+	for _, r := range results {
+		if r.err != nil {
+			fmt.Fprintln(o.Streams.ErrOut, r.err.Error())
+			continue
+		}
+		matrix = append(matrix, r.rows...)
+	}
+
+	buf := bytes.NewBuffer(nil)
+	writer.WriteResults(buf, append([]string{"CONTEXT"}, headers...), matrix, noHeader)
+	fmt.Fprintf(o.Streams.Out, "%s", buf.String())
 
 	return nil
 }

--- a/pkg/cmd/persistentvolumeclaims.go
+++ b/pkg/cmd/persistentvolumeclaims.go
@@ -1,12 +1,11 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
+	"github.com/ricoberger/kubectl-issues/pkg/client"
 	"github.com/ricoberger/kubectl-issues/pkg/cmd/utils"
-	"github.com/ricoberger/kubectl-issues/pkg/writer"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -25,7 +24,7 @@ func newPersistentVolumeClaimsOptions(options IssuesOptions) *PersistentVolumeCl
 	}
 }
 
-func newPersistentVolumeClaimsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
+func newPersistentVolumeClaimsCommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Command {
 	o := newPersistentVolumeClaimsOptions(options)
 
 	cmd := &cobra.Command{
@@ -34,13 +33,14 @@ func newPersistentVolumeClaimsCommand(factory cmdutil.Factory, options IssuesOpt
 		Short:        "List issues with PersistentVolumeClaims",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
-			if err := o.Complete(factory, c); err != nil {
+			if err := o.Complete(c); err != nil {
 				return err
 			}
 
 			ctx := context.Background()
 			noHeader := c.Flag("no-headers").Changed
-			if err := o.Run(ctx, noHeader); err != nil {
+			headers := []string{"NAMESPACE", "NAME", "STATUS", "VOLUME", "CAPACITY", "ACCESS MODES", "STORAGECLASS", "AGE"}
+			if err := o.RunAcrossContexts(ctx, noHeader, headers, o.rows); err != nil {
 				fmt.Fprintln(options.Streams.ErrOut, err.Error())
 				return nil
 			}
@@ -53,15 +53,10 @@ func newPersistentVolumeClaimsCommand(factory cmdutil.Factory, options IssuesOpt
 	return cmd
 }
 
-func (o *PersistentVolumeClaimsOptions) Run(ctx context.Context, noHeader bool) error {
-	client, err := o.GetClient()
+func (o *PersistentVolumeClaimsOptions) rows(ctx context.Context, contextClient client.ContextClient) ([][]string, error) {
+	pvcs, err := contextClient.Client.CoreV1().PersistentVolumeClaims(contextClient.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return err
-	}
-
-	pvcs, err := client.CoreV1().PersistentVolumeClaims(o.namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var matrix [][]string
@@ -77,11 +72,5 @@ func (o *PersistentVolumeClaimsOptions) Run(ctx context.Context, noHeader bool) 
 		}
 	}
 
-	headers := []string{"NAMESPACE", "NAME", "STATUS", "VOLUME", "CAPACITY", "ACCESS MODES", "STORAGECLASS", "AGE"}
-
-	buf := bytes.NewBuffer(nil)
-	writer.WriteResults(buf, headers, matrix, noHeader)
-	fmt.Printf("%s", buf.String())
-
-	return nil
+	return matrix, nil
 }

--- a/pkg/cmd/persistentvolumes.go
+++ b/pkg/cmd/persistentvolumes.go
@@ -1,12 +1,11 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
+	"github.com/ricoberger/kubectl-issues/pkg/client"
 	"github.com/ricoberger/kubectl-issues/pkg/cmd/utils"
-	"github.com/ricoberger/kubectl-issues/pkg/writer"
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
@@ -25,7 +24,7 @@ func newPersistentVolumesOptions(options IssuesOptions) *PersistentVolumesOption
 	}
 }
 
-func newPersistentVolumesCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
+func newPersistentVolumesCommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Command {
 	o := newPersistentVolumesOptions(options)
 
 	cmd := &cobra.Command{
@@ -34,13 +33,14 @@ func newPersistentVolumesCommand(factory cmdutil.Factory, options IssuesOptions)
 		Short:        "List issues with PersistentVolumes",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
-			if err := o.Complete(factory, c); err != nil {
+			if err := o.Complete(c); err != nil {
 				return err
 			}
 
 			ctx := context.Background()
 			noHeader := c.Flag("no-headers").Changed
-			if err := o.Run(ctx, noHeader); err != nil {
+			headers := []string{"NAME", "CAPACITY", "ACCESS MODES", "RECLAIM POLICY", "STATUS", "CLAIM", "STORAGECLASS", "REASON", "AGE"}
+			if err := o.RunAcrossContexts(ctx, noHeader, headers, o.rows); err != nil {
 				fmt.Fprintln(options.Streams.ErrOut, err.Error())
 				return nil
 			}
@@ -53,15 +53,10 @@ func newPersistentVolumesCommand(factory cmdutil.Factory, options IssuesOptions)
 	return cmd
 }
 
-func (o *PersistentVolumesOptions) Run(ctx context.Context, noHeader bool) error {
-	client, err := o.GetClient()
+func (o *PersistentVolumesOptions) rows(ctx context.Context, contextClient client.ContextClient) ([][]string, error) {
+	pvs, err := contextClient.Client.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return err
-	}
-
-	pvs, err := client.CoreV1().PersistentVolumes().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var matrix [][]string
@@ -77,11 +72,5 @@ func (o *PersistentVolumesOptions) Run(ctx context.Context, noHeader bool) error
 		}
 	}
 
-	headers := []string{"NAME", "CAPACITY", "ACCESS MODES", "RECLAIM POLICY", "STATUS", "CLAIM", "STORAGECLASS", "REASON", "AGE"}
-
-	buf := bytes.NewBuffer(nil)
-	writer.WriteResults(buf, headers, matrix, noHeader)
-	fmt.Printf("%s", buf.String())
-
-	return nil
+	return matrix, nil
 }

--- a/pkg/cmd/pods.go
+++ b/pkg/cmd/pods.go
@@ -1,13 +1,12 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"time"
 
+	"github.com/ricoberger/kubectl-issues/pkg/client"
 	"github.com/ricoberger/kubectl-issues/pkg/pods"
-	"github.com/ricoberger/kubectl-issues/pkg/writer"
 
 	"github.com/spf13/cobra"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -25,7 +24,7 @@ func newPodsOptions(options IssuesOptions) *PodsOptions {
 	}
 }
 
-func newPodsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
+func newPodsCommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Command {
 	o := newPodsOptions(options)
 
 	cmd := &cobra.Command{
@@ -34,13 +33,14 @@ func newPodsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Comma
 		Short:        "List issues with Pods",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
-			if err := o.Complete(factory, c); err != nil {
+			if err := o.Complete(c); err != nil {
 				return err
 			}
 
 			ctx := context.Background()
 			noHeader := c.Flag("no-headers").Changed
-			if err := o.Run(ctx, noHeader); err != nil {
+			headers := []string{"NAMESPACE", "NAME", "READY", "STATUS", "RESTARTS", "AGE"}
+			if err := o.RunAcrossContexts(ctx, noHeader, headers, o.rows); err != nil {
 				fmt.Fprintln(options.Streams.ErrOut, err.Error())
 				return nil
 			}
@@ -57,18 +57,13 @@ func newPodsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Comma
 	return cmd
 }
 
-func (o *PodsOptions) Run(ctx context.Context, noHeader bool) error {
-	client, err := o.GetClient()
-	if err != nil {
-		return err
-	}
-
-	unhealthy, err := pods.ListUnhealthy(ctx, client, o.namespace, "", pods.Options{
+func (o *PodsOptions) rows(ctx context.Context, contextClient client.ContextClient) ([][]string, error) {
+	unhealthy, err := pods.ListUnhealthy(ctx, contextClient.Client, contextClient.Namespace, "", pods.Options{
 		RestartThreshold: o.restartThreshold,
 		RestartWindow:    o.restartWindow,
 	})
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var matrix [][]string
@@ -76,11 +71,5 @@ func (o *PodsOptions) Run(ctx context.Context, noHeader bool) error {
 		matrix = append(matrix, []string{pod.Namespace, pod.Name, pod.Ready, pod.Status, pod.Restarts, pod.Age})
 	}
 
-	headers := []string{"NAMESPACE", "NAME", "READY", "STATUS", "RESTARTS", "AGE"}
-
-	buf := bytes.NewBuffer(nil)
-	writer.WriteResults(buf, headers, matrix, noHeader)
-	fmt.Printf("%s", buf.String())
-
-	return nil
+	return matrix, nil
 }

--- a/pkg/cmd/replicasets.go
+++ b/pkg/cmd/replicasets.go
@@ -1,12 +1,11 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
+	"github.com/ricoberger/kubectl-issues/pkg/client"
 	"github.com/ricoberger/kubectl-issues/pkg/cmd/utils"
-	"github.com/ricoberger/kubectl-issues/pkg/writer"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +22,7 @@ func newReplicaSetsOptions(options IssuesOptions) *ReplicaSetsOptions {
 	}
 }
 
-func newReplicaSetsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
+func newReplicaSetsCommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Command {
 	o := newReplicaSetsOptions(options)
 
 	cmd := &cobra.Command{
@@ -32,13 +31,14 @@ func newReplicaSetsCommand(factory cmdutil.Factory, options IssuesOptions) *cobr
 		Short:        "List issues with ReplicaSets",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
-			if err := o.Complete(factory, c); err != nil {
+			if err := o.Complete(c); err != nil {
 				return err
 			}
 
 			ctx := context.Background()
 			noHeader := c.Flag("no-headers").Changed
-			if err := o.Run(ctx, noHeader); err != nil {
+			headers := []string{"NAMESPACE", "NAME", "DESIRED", "CURRENT", "READY", "AGE"}
+			if err := o.RunAcrossContexts(ctx, noHeader, headers, o.rows); err != nil {
 				fmt.Fprintln(options.Streams.ErrOut, err.Error())
 				return nil
 			}
@@ -51,15 +51,10 @@ func newReplicaSetsCommand(factory cmdutil.Factory, options IssuesOptions) *cobr
 	return cmd
 }
 
-func (o *ReplicaSetsOptions) Run(ctx context.Context, noHeader bool) error {
-	client, err := o.GetClient()
+func (o *ReplicaSetsOptions) rows(ctx context.Context, contextClient client.ContextClient) ([][]string, error) {
+	replicaSets, err := contextClient.Client.AppsV1().ReplicaSets(contextClient.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return err
-	}
-
-	replicaSets, err := client.AppsV1().ReplicaSets(o.namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var matrix [][]string
@@ -71,11 +66,5 @@ func (o *ReplicaSetsOptions) Run(ctx context.Context, noHeader bool) error {
 		}
 	}
 
-	headers := []string{"NAMESPACE", "NAME", "DESIRED", "CURRENT", "READY", "AGE"}
-
-	buf := bytes.NewBuffer(nil)
-	writer.WriteResults(buf, headers, matrix, noHeader)
-	fmt.Printf("%s", buf.String())
-
-	return nil
+	return matrix, nil
 }

--- a/pkg/cmd/statefulsets.go
+++ b/pkg/cmd/statefulsets.go
@@ -1,12 +1,11 @@
 package cmd
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 
+	"github.com/ricoberger/kubectl-issues/pkg/client"
 	"github.com/ricoberger/kubectl-issues/pkg/cmd/utils"
-	"github.com/ricoberger/kubectl-issues/pkg/writer"
 
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -23,7 +22,7 @@ func newStatefulSetsOptions(options IssuesOptions) *StatefulSetsOptions {
 	}
 }
 
-func newStatefulSetsCommand(factory cmdutil.Factory, options IssuesOptions) *cobra.Command {
+func newStatefulSetsCommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Command {
 	o := newStatefulSetsOptions(options)
 
 	cmd := &cobra.Command{
@@ -32,13 +31,14 @@ func newStatefulSetsCommand(factory cmdutil.Factory, options IssuesOptions) *cob
 		Short:        "List issues with StatefulSets",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
-			if err := o.Complete(factory, c); err != nil {
+			if err := o.Complete(c); err != nil {
 				return err
 			}
 
 			ctx := context.Background()
 			noHeader := c.Flag("no-headers").Changed
-			if err := o.Run(ctx, noHeader); err != nil {
+			headers := []string{"NAMESPACE", "NAME", "READY", "UP-TO-DATE", "AVAILABLE", "AGE"}
+			if err := o.RunAcrossContexts(ctx, noHeader, headers, o.rows); err != nil {
 				fmt.Fprintln(options.Streams.ErrOut, err.Error())
 				return nil
 			}
@@ -51,15 +51,10 @@ func newStatefulSetsCommand(factory cmdutil.Factory, options IssuesOptions) *cob
 	return cmd
 }
 
-func (o *StatefulSetsOptions) Run(ctx context.Context, noHeader bool) error {
-	client, err := o.GetClient()
+func (o *StatefulSetsOptions) rows(ctx context.Context, contextClient client.ContextClient) ([][]string, error) {
+	statefulSets, err := contextClient.Client.AppsV1().StatefulSets(contextClient.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return err
-	}
-
-	statefulSets, err := client.AppsV1().StatefulSets(o.namespace).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
+		return nil, err
 	}
 
 	var matrix [][]string
@@ -71,11 +66,5 @@ func (o *StatefulSetsOptions) Run(ctx context.Context, noHeader bool) error {
 		}
 	}
 
-	headers := []string{"NAMESPACE", "NAME", "READY", "UP-TO-DATE", "AVAILABLE", "AGE"}
-
-	buf := bytes.NewBuffer(nil)
-	writer.WriteResults(buf, headers, matrix, noHeader)
-	fmt.Printf("%s", buf.String())
-
-	return nil
+	return matrix, nil
 }

--- a/pkg/cmd/tui.go
+++ b/pkg/cmd/tui.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"time"
+
 	"github.com/ricoberger/kubectl-issues/pkg/pods"
 	"github.com/ricoberger/kubectl-issues/pkg/tui"
 
@@ -8,22 +10,47 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 )
 
+type TUIOptions struct {
+	IssuesOptions
+	restartThreshold int
+	restartWindow    time.Duration
+}
+
+func newTUIOptions(options IssuesOptions) *TUIOptions {
+	return &TUIOptions{
+		IssuesOptions: options,
+	}
+}
+
 func newTUICommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Command {
-	var contexts []string
-	podsOptions := pods.DefaultOptions()
+	o := newTUIOptions(options)
 
 	cmd := &cobra.Command{
 		Use:          "tui",
 		Short:        "Show all unhealthy Pods across one or more contexts in a TUI",
 		SilenceUsage: true,
 		RunE: func(c *cobra.Command, args []string) error {
-			return tui.Start(contexts, options.ConfigFlags, podsOptions)
+			if err := o.Complete(c); err != nil {
+				return err
+			}
+
+			clients, err := o.GetClients()
+			if err != nil {
+				return err
+			}
+
+			return tui.Start(clients, pods.Options{
+				RestartThreshold: o.restartThreshold,
+				RestartWindow:    o.restartWindow,
+			})
 		},
 	}
 
-	cmd.Flags().StringArrayVar(&contexts, "context", nil, "The name of the kubeconfig context to use. Can be specified multiple times to show unhealthy Pods from multiple clusters.")
-	cmd.Flags().IntVar(&podsOptions.RestartThreshold, "restart-threshold", podsOptions.RestartThreshold, "Minimum restart count before a Ready Pod with a recent crash is reported. 0 only reports Pods which are not Ready, 1 reports any recent crash.")
-	cmd.Flags().DurationVar(&podsOptions.RestartWindow, "restart-window", podsOptions.RestartWindow, "How recent the last crash of a container must be for a Ready Pod to be reported.")
+	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
+
+	defaults := pods.DefaultOptions()
+	cmd.Flags().IntVar(&o.restartThreshold, "restart-threshold", defaults.RestartThreshold, "Minimum restart count before a Ready Pod with a recent crash is reported. 0 only reports Pods which are not Ready, 1 reports any recent crash.")
+	cmd.Flags().DurationVar(&o.restartWindow, "restart-window", defaults.RestartWindow, "How recent the last crash of a container must be for a Ready Pod to be reported.")
 
 	return cmd
 }

--- a/pkg/tui/model.go
+++ b/pkg/tui/model.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ricoberger/kubectl-issues/pkg/client"
 	"github.com/ricoberger/kubectl-issues/pkg/pods"
 
 	tea "charm.land/bubbletea/v2"
@@ -66,7 +67,7 @@ type podsMsg struct {
 }
 
 // fetchCmd fetches the unhealthy Pods from all contexts in parallel.
-func fetchCmd(clients []ContextClient, podsOptions pods.Options) tea.Cmd {
+func fetchCmd(clients []client.ContextClient, podsOptions pods.Options) tea.Cmd {
 	return func() tea.Msg {
 		var (
 			wg       sync.WaitGroup
@@ -75,29 +76,29 @@ func fetchCmd(clients []ContextClient, podsOptions pods.Options) tea.Cmd {
 			firstErr error
 		)
 
-		for _, client := range clients {
+		for _, contextClient := range clients {
 			wg.Add(1)
 
-			go func(client ContextClient) {
+			go func(contextClient client.ContextClient) {
 				defer wg.Done()
 
 				ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
 				defer cancel()
 
-				result, err := pods.ListUnhealthy(ctx, client.Client, "", client.Name, podsOptions)
+				result, err := pods.ListUnhealthy(ctx, contextClient.Client, contextClient.Namespace, contextClient.Name, podsOptions)
 
 				mu.Lock()
 				defer mu.Unlock()
 
 				if err != nil {
 					if firstErr == nil {
-						firstErr = fmt.Errorf("%s: %w", client.Name, err)
+						firstErr = fmt.Errorf("%s: %w", contextClient.Name, err)
 					}
 					return
 				}
 
 				items = append(items, result...)
-			}(client)
+			}(contextClient)
 		}
 
 		wg.Wait()
@@ -120,7 +121,7 @@ type Model struct {
 	ScreenWidth  int
 	ScreenHeight int
 
-	Clients     []ContextClient
+	Clients     []client.ContextClient
 	PodsOptions pods.Options
 	Table       table.Model
 
@@ -129,7 +130,7 @@ type Model struct {
 	lastUpdated time.Time
 }
 
-func NewModel(clients []ContextClient, podsOptions pods.Options) tea.Model {
+func NewModel(clients []client.ContextClient, podsOptions pods.Options) tea.Model {
 	return &Model{
 		Clients:     clients,
 		PodsOptions: podsOptions,

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -1,46 +1,15 @@
 package tui
 
 import (
-	"fmt"
-
+	"github.com/ricoberger/kubectl-issues/pkg/client"
 	"github.com/ricoberger/kubectl-issues/pkg/pods"
 
 	tea "charm.land/bubbletea/v2"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
-// ContextClient is a Kubernetes client for a single kubeconfig context. The
-// Name is the (resolved) name of the context and is shown in the table.
-type ContextClient struct {
-	Name   string
-	Client kubernetes.Interface
-}
-
-// Start builds a Kubernetes client for every given context and starts the TUI.
-// If no contexts are given, the current context of the kubeconfig is used. The
+// Start starts the TUI showing the unhealthy Pods from all given clients. The
 // podsOptions tune which Pods are considered unhealthy.
-func Start(contexts []string, configFlags *genericclioptions.ConfigFlags, podsOptions pods.Options) error {
-	kubeconfig := ""
-	if configFlags != nil && configFlags.KubeConfig != nil {
-		kubeconfig = *configFlags.KubeConfig
-	}
-
-	if len(contexts) == 0 {
-		contexts = []string{""}
-	}
-
-	var clients []ContextClient
-	for _, name := range contexts {
-		client, resolvedName, err := newClient(kubeconfig, name)
-		if err != nil {
-			return fmt.Errorf("failed to create client for context %q: %w", name, err)
-		}
-
-		clients = append(clients, ContextClient{Name: resolvedName, Client: client})
-	}
-
+func Start(clients []client.ContextClient, podsOptions pods.Options) error {
 	model := NewModel(clients, podsOptions)
 
 	p := tea.NewProgram(model)
@@ -49,40 +18,4 @@ func Start(contexts []string, configFlags *genericclioptions.ConfigFlags, podsOp
 	}
 
 	return nil
-}
-
-// newClient creates a Kubernetes client for the given kubeconfig context. If
-// the context name is empty, the current context of the kubeconfig is used. The
-// resolved context name is returned as the second return value.
-func newClient(kubeconfig, contextName string) (kubernetes.Interface, string, error) {
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	if kubeconfig != "" {
-		loadingRules.ExplicitPath = kubeconfig
-	}
-
-	overrides := &clientcmd.ConfigOverrides{}
-	if contextName != "" {
-		overrides.CurrentContext = contextName
-	}
-
-	clientConfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, overrides)
-
-	resolvedName := contextName
-	if resolvedName == "" {
-		if rawConfig, err := clientConfig.RawConfig(); err == nil {
-			resolvedName = rawConfig.CurrentContext
-		}
-	}
-
-	restConfig, err := clientConfig.ClientConfig()
-	if err != nil {
-		return nil, resolvedName, err
-	}
-
-	client, err := kubernetes.NewForConfig(restConfig)
-	if err != nil {
-		return nil, resolvedName, err
-	}
-
-	return client, resolvedName, nil
 }


### PR DESCRIPTION
The repeatable `--context` flag was previously only available for the tui
subcommand. The single-valued `--context` flag from the kubectl config
flags is now replaced with a repeatable, persistent flag, so that all
subcommands can list issues across multiple clusters at once.

Clients are built by the new `pkg/client` package, which resolves the
namespace per context: an explicit `--namespace` applies to all contexts,
`--all-namespaces` means all namespaces everywhere, otherwise each
context's kubeconfig namespace is used. A shared runner fetches all
contexts in parallel, groups the rows in flag order and prints a
failing context's error to stderr without hiding the results of the
other contexts.

BREAKING CHANGE: All subcommands now always print a leading CONTEXT
column. The tui subcommand no longer shows all namespaces by default,
it uses the context's default namespace like the other subcommands and
supports `--namespace` and `--all-namespaces`.