### PR TITLE
feat(cmd): add --output flag to print results as JSON

### DIFF
--- a/pkg/cmd/daemonsets.go
+++ b/pkg/cmd/daemonsets.go
@@ -47,6 +47,7 @@ func newDaemonSetsCommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Comma
 	}
 
 	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "Output format. One of: json.")
 
 	return cmd
 }

--- a/pkg/cmd/deployments.go
+++ b/pkg/cmd/deployments.go
@@ -47,6 +47,7 @@ func newDeploymentsCommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Comm
 	}
 
 	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "Output format. One of: json.")
 
 	return cmd
 }

--- a/pkg/cmd/issues.go
+++ b/pkg/cmd/issues.go
@@ -8,6 +8,9 @@ import (
 var cmdExample = `  # List issues with Pods
   kubectl issues pods
 
+  # List issues with Pods as JSON
+  kubectl issues pods --output json
+
   # List issues with Pods across multiple contexts
   kubectl issues pods --all-namespaces --context staging --context production
 

--- a/pkg/cmd/jobs.go
+++ b/pkg/cmd/jobs.go
@@ -47,6 +47,7 @@ func newJobsCommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Command {
 	}
 
 	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "Output format. One of: json.")
 
 	return cmd
 }

--- a/pkg/cmd/nodes.go
+++ b/pkg/cmd/nodes.go
@@ -49,6 +49,7 @@ func newNodesCommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Command {
 	}
 
 	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "Output format. One of: json.")
 
 	return cmd
 }

--- a/pkg/cmd/options.go
+++ b/pkg/cmd/options.go
@@ -20,6 +20,7 @@ type IssuesOptions struct {
 	ResourceBuilderFlags *genericclioptions.ResourceBuilderFlags
 	contexts             []string
 	allNamespaces        bool
+	output               string
 }
 
 func NewIssuesOptions() IssuesOptions {
@@ -51,6 +52,10 @@ func (o *IssuesOptions) Complete(cmd *cobra.Command) error {
 	}
 	o.contexts = contexts
 
+	if o.output != "" && o.output != "json" {
+		return fmt.Errorf("invalid output format %q, allowed formats are: json", o.output)
+	}
+
 	return nil
 }
 
@@ -80,10 +85,11 @@ func (o *IssuesOptions) GetClients() ([]client.ContextClient, error) {
 type rowsFunc func(ctx context.Context, contextClient client.ContextClient) ([][]string, error)
 
 // RunAcrossContexts collects the table rows from all requested contexts in
-// parallel and prints them as a single table with a leading CONTEXT column.
-// The rows are grouped in the order the contexts were specified. An error in
-// one context is printed to stderr and does not hide the results of the other
-// contexts.
+// RunAcrossContexts collects the table rows from all requested contexts in
+// parallel and prints them as a single table with a leading CONTEXT column,
+// or as JSON if the output format is set to "json". The rows are grouped in
+// the order the contexts were specified. An error in one context is printed
+// to stderr and does not hide the results of the other contexts.
 func (o *IssuesOptions) RunAcrossContexts(ctx context.Context, noHeader bool, headers []string, rows rowsFunc) error {
 	clients, err := o.GetClients()
 	if err != nil {
@@ -126,8 +132,14 @@ func (o *IssuesOptions) RunAcrossContexts(ctx context.Context, noHeader bool, he
 		matrix = append(matrix, r.rows...)
 	}
 
+	allHeaders := append([]string{"CONTEXT"}, headers...)
+
+	if o.output == "json" {
+		return writer.WriteJSON(o.Streams.Out, allHeaders, matrix)
+	}
+
 	buf := bytes.NewBuffer(nil)
-	writer.WriteResults(buf, append([]string{"CONTEXT"}, headers...), matrix, noHeader)
+	writer.WriteResults(buf, allHeaders, matrix, noHeader)
 	fmt.Fprintf(o.Streams.Out, "%s", buf.String())
 
 	return nil

--- a/pkg/cmd/persistentvolumeclaims.go
+++ b/pkg/cmd/persistentvolumeclaims.go
@@ -49,6 +49,7 @@ func newPersistentVolumeClaimsCommand(_ cmdutil.Factory, options IssuesOptions) 
 	}
 
 	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "Output format. One of: json.")
 
 	return cmd
 }

--- a/pkg/cmd/persistentvolumes.go
+++ b/pkg/cmd/persistentvolumes.go
@@ -49,6 +49,7 @@ func newPersistentVolumesCommand(_ cmdutil.Factory, options IssuesOptions) *cobr
 	}
 
 	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "Output format. One of: json.")
 
 	return cmd
 }

--- a/pkg/cmd/pods.go
+++ b/pkg/cmd/pods.go
@@ -49,6 +49,7 @@ func newPodsCommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Command {
 	}
 
 	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "Output format. One of: json.")
 
 	defaults := pods.DefaultOptions()
 	cmd.Flags().IntVar(&o.restartThreshold, "restart-threshold", defaults.RestartThreshold, "Minimum restart count before a Ready Pod with a recent crash is reported. 0 only reports Pods which are not Ready, 1 reports any recent crash.")

--- a/pkg/cmd/replicasets.go
+++ b/pkg/cmd/replicasets.go
@@ -47,6 +47,7 @@ func newReplicaSetsCommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Comm
 	}
 
 	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "Output format. One of: json.")
 
 	return cmd
 }

--- a/pkg/cmd/statefulsets.go
+++ b/pkg/cmd/statefulsets.go
@@ -47,6 +47,7 @@ func newStatefulSetsCommand(_ cmdutil.Factory, options IssuesOptions) *cobra.Com
 	}
 
 	o.ResourceBuilderFlags.AddFlags(cmd.Flags())
+	cmd.Flags().StringVarP(&o.output, "output", "o", "", "Output format. One of: json.")
 
 	return cmd
 }

--- a/pkg/writer/writer.go
+++ b/pkg/writer/writer.go
@@ -1,6 +1,8 @@
 package writer
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
@@ -22,4 +24,58 @@ func WriteResults(out io.Writer, headers []string, matrix [][]string, noHeader b
 			fmt.Fprintln(w, strings.Join(row, "\t"))
 		}
 	}
+}
+
+// jsonRow marshals a single table row as a JSON object which uses the table
+// headers as keys, preserving the column order of the table.
+type jsonRow struct {
+	headers []string
+	values  []string
+}
+
+func (r jsonRow) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+
+	for i, header := range r.headers {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+
+		key, err := json.Marshal(header)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(key)
+		buf.WriteByte(':')
+
+		value, err := json.Marshal(r.values[i])
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(value)
+	}
+
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+// WriteJSON writes the results as a JSON array of objects, so they can be
+// consumed by other applications. The keys of each object are the table
+// headers in column order, the values are the formatted strings of the table,
+// so that a consumer can reprint the identical table. An empty matrix is
+// written as an empty array.
+func WriteJSON(out io.Writer, headers []string, matrix [][]string) error {
+	rows := make([]jsonRow, 0, len(matrix))
+	for _, row := range matrix {
+		rows = append(rows, jsonRow{headers: headers, values: row})
+	}
+
+	result, err := json.MarshalIndent(rows, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	_, err = fmt.Fprintf(out, "%s\n", result)
+	return err
 }

--- a/pkg/writer/writer_test.go
+++ b/pkg/writer/writer_test.go
@@ -1,0 +1,58 @@
+package writer
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestWriteJSON(t *testing.T) {
+	headers := []string{"CONTEXT", "NAME", "UP-TO-DATE", "ACCESS MODES"}
+	matrix := [][]string{
+		{"staging", "app-1", "1", "RWO"},
+		{"production", "app-2", "2", "RWX"},
+	}
+
+	buf := bytes.NewBuffer(nil)
+	if err := WriteJSON(buf, headers, matrix); err != nil {
+		t.Fatalf("WriteJSON() error = %v", err)
+	}
+
+	want := `[
+  {
+    "CONTEXT": "staging",
+    "NAME": "app-1",
+    "UP-TO-DATE": "1",
+    "ACCESS MODES": "RWO"
+  },
+  {
+    "CONTEXT": "production",
+    "NAME": "app-2",
+    "UP-TO-DATE": "2",
+    "ACCESS MODES": "RWX"
+  }
+]
+`
+	if got := buf.String(); got != want {
+		t.Errorf("WriteJSON() = %q, want %q", got, want)
+	}
+
+	var decoded []map[string]string
+	if err := json.Unmarshal(buf.Bytes(), &decoded); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	if len(decoded) != 2 {
+		t.Errorf("decoded %d objects, want 2", len(decoded))
+	}
+}
+
+func TestWriteJSONEmpty(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	if err := WriteJSON(buf, []string{"CONTEXT", "NAME"}, nil); err != nil {
+		t.Fatalf("WriteJSON() error = %v", err)
+	}
+
+	if got := buf.String(); got != "[]\n" {
+		t.Errorf("WriteJSON() = %q, want %q", got, "[]\n")
+	}
+}


### PR DESCRIPTION
All resource subcommands accept a new `-o`/`--output` flag with `json` as the
only supported format, so the results can be consumed by other
applications. Each row is an object which uses the exact table headers
as keys in column order and the formatted table cells as values, so a
consumer can reprint the identical table. An empty result is an empty
array instead of the "No resources found" message and per-context
errors keep going to stderr, so stdout always carries valid JSON.

The `tui` subcommand intentionally does not get the flag, since machine
readable output makes no sense for an interactive view.